### PR TITLE
Internal SecureRos pull request

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(roscpp
   src/libros/poll_set.cpp
   src/libros/service.cpp
   src/libros/this_node.cpp
+  src/libros/url.cpp
   )
 
 add_dependencies(roscpp ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/clients/roscpp/include/ros/connection.h
+++ b/clients/roscpp/include/ros/connection.h
@@ -174,6 +174,7 @@ public:
 
   std::string getCallerId();
   std::string getRemoteString();
+  std::string getClientURI();
 
 private:
   /**

--- a/clients/roscpp/include/ros/master.h
+++ b/clients/roscpp/include/ros/master.h
@@ -118,6 +118,21 @@ ROSCPP_DECL bool getTopics(V_TopicInfo& topics);
 ROSCPP_DECL bool getNodes(V_string& nodes);
 
 /**
+ * \brief Retrieves the currently-known list of subscribers nodes of topic from the master
+ */
+ROSCPP_DECL bool getSubscriberNodes(V_string& sub_nodes, const std::string topic);
+
+/**
+ * \brief Retrieves the list of authorized clients of service from the master
+ */
+ROSCPP_DECL bool getServiceClients(V_string& sub_nodes, const std::string service);
+
+/**
+ * \brief Retrieves the currently-known list of subscriber hosts of topic from the master
+ */
+ROSCPP_DECL bool getSubscriberHosts(V_string& sub_hosts, const std::string topic);
+
+/**
  * @brief Set the max time this node should spend looping trying to connect to the master
  * @param The timeout.  A negative value means infinite
  */

--- a/clients/roscpp/include/ros/topic_manager.h
+++ b/clients/roscpp/include/ros/topic_manager.h
@@ -40,7 +40,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
-static const char AUTH[] = "roslaunch.auth";
+static const char AUTH_LOG_NAME[] = "roscpp.auth";
 
 namespace ros
 {

--- a/clients/roscpp/include/ros/topic_manager.h
+++ b/clients/roscpp/include/ros/topic_manager.h
@@ -31,12 +31,16 @@
 #include "forwards.h"
 #include "common.h"
 #include "ros/serialization.h"
+#include "ros/url.h"
 #include "rosout_appender.h"
 
 #include "xmlrpcpp/XmlRpcValue.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
+
+static const char AUTH[] = "roslaunch.auth";
 
 namespace ros
 {
@@ -59,6 +63,9 @@ typedef boost::shared_ptr<ConnectionManager> ConnectionManagerPtr;
 
 class SubscriptionCallbackHelper;
 typedef boost::shared_ptr<SubscriptionCallbackHelper> SubscriptionCallbackHelperPtr;
+
+bool is_subscriber_authorized( const std::string& topic, const std::string& client_ip_address );
+bool is_requester_authorized( const std::string& service, const std::string& client_ip_address );
 
 class ROSCPP_DECL TopicManager
 {
@@ -210,7 +217,9 @@ private:
   bool pubUpdate(const std::string &topic, const std::vector<std::string> &pubs);
 
   void pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);
+  void pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info);
   void requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);
+  void requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info);
   void getBusStatsCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);
   void getBusInfoCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);
   void getSubscriptionsCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -122,6 +122,11 @@ public:
   virtual std::string getTransportInfo() = 0;
 
   /**
+   * \brief Returns a string description of both the type of transport and who the transport is connected to
+   */
+  virtual std::string getClientURI() = 0;
+
+  /**
    * \brief Returns a boolean to indicate if the transport mechanism is reliable or not
    */
   virtual bool requiresHeader() {return true;}

--- a/clients/roscpp/include/ros/url.h
+++ b/clients/roscpp/include/ros/url.h
@@ -1,5 +1,5 @@
-#ifndef _URL_H_
-#define _URL_H_    
+#ifndef ROSCPP_URL_H_
+#define ROSCPP_URL_H_    
 
 #include <string>
 
@@ -27,4 +27,4 @@ class URLParser {
     std::string url_, protocol_, host_, path_, query_, ip_address_, port_;
 };
 
-#endif // _URL_H_ 
+#endif // ROSCPP_URL_H_ 

--- a/clients/roscpp/include/ros/url.h
+++ b/clients/roscpp/include/ros/url.h
@@ -1,0 +1,30 @@
+#ifndef _URL_H_
+#define _URL_H_    
+
+#include <string>
+
+std::string uri_to_ip_address( const std::string uri );
+
+bool is_uri_match( const std::string uri, const std::string ip_address );
+
+class URLParser {
+  public:
+    URLParser(const std::string url_s); 
+    ~URLParser( );
+
+    bool match( const std::string ip_address );
+
+    std::string get_host();
+
+    inline std::string get_ip_address() { return ip_address_; }
+    inline std::string get_port() { return port_; }
+    inline std::string get_protocol() { return protocol_; }
+
+  private:
+    void parse(const std::string& url_s);
+
+  private:
+    std::string url_, protocol_, host_, path_, query_, ip_address_, port_;
+};
+
+#endif // _URL_H_ 

--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -89,7 +89,8 @@ public:
 class XMLRPCManager;
 typedef boost::shared_ptr<XMLRPCManager> XMLRPCManagerPtr;
 
-typedef boost::function<void(XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcValue&)> XMLRPCFunc;
+typedef boost::function<void(XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcValue&)> XMLRPCFunc_deprecated;
+typedef boost::function<void(XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcClientInfo&)> XMLRPCFunc;
 
 class ROSCPP_DECL XMLRPCManager
 {
@@ -124,6 +125,7 @@ public:
   void addASyncConnection(const ASyncXMLRPCConnectionPtr& conn);
   void removeASyncConnection(const ASyncXMLRPCConnectionPtr& conn);
 
+  //bool bind(const std::string& function_name, const XMLRPCFunc_deprecated& cb);
   bool bind(const std::string& function_name, const XMLRPCFunc& cb);
   void unbind(const std::string& function_name);
 

--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -125,7 +125,6 @@ public:
   void addASyncConnection(const ASyncXMLRPCConnectionPtr& conn);
   void removeASyncConnection(const ASyncXMLRPCConnectionPtr& conn);
 
-  //bool bind(const std::string& function_name, const XMLRPCFunc_deprecated& cb);
   bool bind(const std::string& function_name, const XMLRPCFunc& cb);
   void unbind(const std::string& function_name);
 

--- a/clients/roscpp/include/ros/xmlrpc_manager.h
+++ b/clients/roscpp/include/ros/xmlrpc_manager.h
@@ -89,7 +89,6 @@ public:
 class XMLRPCManager;
 typedef boost::shared_ptr<XMLRPCManager> XMLRPCManagerPtr;
 
-typedef boost::function<void(XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcValue&)> XMLRPCFunc_deprecated;
 typedef boost::function<void(XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcValue&, XmlRpc::XmlRpcClientInfo&)> XMLRPCFunc;
 
 class ROSCPP_DECL XMLRPCManager

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -476,4 +476,9 @@ std::string Connection::getRemoteString()
   return ss.str();
 }
 
+std::string Connection::getClientURI()
+{
+  return transport_->getClientURI();
+}
+
 }

--- a/clients/roscpp/src/libros/connection_manager.cpp
+++ b/clients/roscpp/src/libros/connection_manager.cpp
@@ -214,7 +214,7 @@ bool ConnectionManager::onConnectionHeaderReceived(const ConnectionPtr& conn, co
     header.getValue( "callerid", caller_id );
     std::string client_ip = uri_to_ip_address( conn->getClientURI() );
     if ( !is_subscriber_authorized( val, client_ip ) ) {
-      ROS_WARN_NAMED( AUTH, "received topic connection for %s from %s (%s) not authorized",
+      ROS_WARN_NAMED(AUTH_LOG_NAME, "received topic connection for %s from %s (%s) not authorized",
           val.c_str(), caller_id.c_str(), conn->getRemoteString().c_str());
       std::stringstream msg;
       msg << "Client [" << caller_id << "] wants topic connection for " << val << ", but " << client_ip << "is not authorized"; 

--- a/clients/roscpp/src/libros/connection_manager.cpp
+++ b/clients/roscpp/src/libros/connection_manager.cpp
@@ -34,6 +34,7 @@
 #include "ros/transport/transport_udp.h"
 #include "ros/file_log.h"
 #include "ros/network.h"
+#include "ros/topic_manager.h"
 
 #include <ros/assert.h>
 
@@ -209,6 +210,18 @@ bool ConnectionManager::onConnectionHeaderReceived(const ConnectionPtr& conn, co
   std::string val;
   if (header.getValue("topic", val))
   {
+    std::string caller_id( "unknown" );
+    header.getValue( "callerid", caller_id );
+    std::string client_ip = uri_to_ip_address( conn->getClientURI() );
+    if ( !is_subscriber_authorized( val, client_ip ) ) {
+      ROS_WARN_NAMED( AUTH, "received topic connection for %s from %s (%s) not authorized",
+          val.c_str(), caller_id.c_str(), conn->getRemoteString().c_str());
+      std::stringstream msg;
+      msg << "Client [" << caller_id << "] wants topic connection for " << val << ", but " << client_ip << "is not authorized"; 
+      conn->sendHeaderError(msg.str());
+      return false;
+    }
+
     ROSCPP_CONN_LOG_DEBUG("Connection: Creating TransportSubscriberLink for topic [%s] connected to [%s]", 
 		     val.c_str(), conn->getRemoteString().c_str());
 

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -174,6 +174,7 @@ void shutdownCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, 
     ROS_WARN("Reason given for shutdown: [%s]", reason.c_str());
     requestShutdown();
   }
+
   result = xmlrpc::responseInt(1, "", 0);
 }
 
@@ -346,7 +347,6 @@ void start()
 
   PollManager::instance()->addPollThreadListener(checkForShutdown);
   XMLRPCManager::instance()->bind("shutdown", shutdownCallback);
-
 
   initInternalTimerManager();
 

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -170,7 +170,7 @@ void shutdownCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, 
   if ( !is_uri_match( ros::master::getURI(), client_info.ip ) ) {
     std::string caller_id( params[0] );
     //std::string msg( params[1] );
-    ROS_WARN_NAMED( AUTH, "shutdown( %s, %s ) not authorized", caller_id.c_str(), client_info.ip.c_str() );
+    ROS_WARN_NAMED(AUTH_LOG_NAME, "shutdown( %s, %s ) not authorized", caller_id.c_str(), client_info.ip.c_str() );
     result = xmlrpc::responseInt(-1, "method not authorized", 0);
     return;
   }

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -345,7 +345,8 @@ void start()
   param::param("/tcp_keepalive", TransportTCP::s_use_keepalive_, TransportTCP::s_use_keepalive_);
 
   PollManager::instance()->addPollThreadListener(checkForShutdown);
-  XMLRPCManager::instance()->bind("shutdown", static_cast<void (*)(XmlRpc::XmlRpcValue& , XmlRpc::XmlRpcValue& , XmlRpc::XmlRpcClientInfo& )>(&shutdownCallback) );
+  XMLRPCManager::instance()->bind("shutdown", shutdownCallback);
+
 
   initInternalTimerManager();
 

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -155,28 +155,22 @@ void atexitCallback()
   }
 }
 
-void shutdownCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
-{
-  (void)params;
-  result = xmlrpc::responseInt(0, "Deprecated function", 0);
-  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
-}
-
 void shutdownCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info)
 {
-  int num_params = 0;
-  if (params.getType() == XmlRpc::XmlRpcValue::TypeArray)
-    num_params = params.size();
   if ( !is_uri_match( ros::master::getURI(), client_info.ip ) ) {
     std::string caller_id( params[0] );
-    //std::string msg( params[1] );
     ROS_WARN_NAMED(AUTH_LOG_NAME, "shutdown( %s, %s ) not authorized", caller_id.c_str(), client_info.ip.c_str() );
     result = xmlrpc::responseInt(-1, "method not authorized", 0);
     return;
   }
+
+  int num_params = 0;
+  if (params.getType() == XmlRpc::XmlRpcValue::TypeArray)
+    num_params = params.size();
   if (num_params > 1)
   {
     std::string reason = params[1];
+    ROS_WARN("Shutdown request received.");
     ROS_WARN("Reason given for shutdown: [%s]", reason.c_str());
     requestShutdown();
   }

--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -35,6 +35,8 @@
 #include <ros/assert.h>
 
 #include "xmlrpcpp/XmlRpc.h"
+#include <iostream>
+#include <sstream> 
 
 namespace ros
 {
@@ -169,6 +171,135 @@ bool getNodes(V_string& nodes)
 
   nodes.insert(nodes.end(), node_set.begin(), node_set.end());
 
+  return true;
+}
+
+std::string XmlRpcValueType( XmlRpc::XmlRpcValue& value ) {
+  std::stringstream ss;
+  if ( value.getType() == XmlRpc::XmlRpcValue::TypeBoolean ) {
+    bool v = value;
+    ss << "Boolean (" << v << ")";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeInt ) {
+    int v = value;
+    ss << "Int (" << v << ")";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeDouble ) {
+    double v = value;
+    ss << "Double (" << v << ")";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeString ) {
+    std::string v = value;
+    ss << "String (" << v << ")";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeDateTime ) {
+    ss << "DateTime";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeBase64 ) {
+    ss << "Base64";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeArray ) {
+    ss << "Array";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeStruct ) {
+    ss << "Struct";
+  }
+  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeInvalid ) {
+    ss << "Invalid";
+  }
+  else {
+    ss << "Other";
+  }
+  return ss.str();
+}
+
+bool getSubscriberNodes(V_string& sub_nodes, const std::string topic)
+{
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = this_node::getName();
+
+  if (!execute("getSystemState", args, result, payload, true))
+  {
+    return false;
+  }
+
+  S_string node_set;
+  {
+    if ( payload.size() != 3 ) {
+      printf( "Expected payload size = 3 (actual is %d)\n", payload.size() );
+      std::cout << "  type: " << XmlRpcValueType( payload ) << std::endl << std::flush;
+      return false;
+    }
+    for (int j = 0; j < payload[1].size(); ++j)
+    {
+      std::string t = payload[1][j][0];
+      if ( t == topic ) {
+        XmlRpc::XmlRpcValue val = payload[1][j][1];
+        for (int k = 0; k < val.size(); ++k)
+        {
+          std::string name = payload[1][j][1][k];
+          node_set.insert(name);
+        }
+      }
+    }
+  }
+
+  sub_nodes.insert(sub_nodes.end(), node_set.begin(), node_set.end());
+
+  return true;
+}
+
+bool getSubscriberHosts(V_string& sub_hosts, const std::string topic) 
+{
+  V_string sub_nodes;
+  getSubscriberNodes( sub_nodes, topic );
+
+  S_string host_set;
+  for ( size_t i = 0; i < sub_nodes.size(); i++ ) {
+    XmlRpc::XmlRpcValue args, result, payload;
+    args[0] = this_node::getName();
+    args[1] = sub_nodes[i];
+
+    if (!execute("lookupNode", args, result, payload, true)) {
+      return false;
+    }
+    if ( payload.getType() != XmlRpc::XmlRpcValue::TypeString ) {
+      printf( "Expected payload to be string\n" );
+      std::cout << "  type: " << XmlRpcValueType( payload ) << std::endl << std::flush;
+      return false;
+    }
+    std::string uri = payload;
+    std::string host;
+    uint32_t port;
+    // Split URI into
+    if (!network::splitURI(uri, host, port)) {
+      ROS_FATAL( "Couldn't parse the URI [%s] into a host:port pair.", uri.c_str());
+      ROS_BREAK();
+    }
+    //else { 
+    //  printf( "[xmlrpc_cpp]    %s -> %s : %d\n", uri.c_str(), host.c_str(), port );
+    //}
+    host_set.insert( host );
+  }
+  sub_hosts.insert( sub_hosts.end(), host_set.begin(), host_set.end() );
+  return true;
+}
+
+
+bool getServiceClients(V_string& sub_hosts, const std::string service) 
+{
+  XmlRpc::XmlRpcValue args, result, payload;
+  args[0] = this_node::getName();
+  args[1] = service;
+
+  if (!execute("getServiceClients", args, result, payload, true)) {
+    return false;
+  }
+
+  for ( int j = 0; j < payload.size(); ++j ) {
+    std::string ip_address = payload[j];
+    sub_hosts.push_back( ip_address );
+  }
   return true;
 }
 

--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -35,8 +35,6 @@
 #include <ros/assert.h>
 
 #include "xmlrpcpp/XmlRpc.h"
-#include <iostream>
-#include <sstream> 
 
 namespace ros
 {
@@ -174,45 +172,6 @@ bool getNodes(V_string& nodes)
   return true;
 }
 
-std::string XmlRpcValueType( XmlRpc::XmlRpcValue& value ) {
-  std::stringstream ss;
-  if ( value.getType() == XmlRpc::XmlRpcValue::TypeBoolean ) {
-    bool v = value;
-    ss << "Boolean (" << v << ")";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeInt ) {
-    int v = value;
-    ss << "Int (" << v << ")";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeDouble ) {
-    double v = value;
-    ss << "Double (" << v << ")";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeString ) {
-    std::string v = value;
-    ss << "String (" << v << ")";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeDateTime ) {
-    ss << "DateTime";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeBase64 ) {
-    ss << "Base64";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeArray ) {
-    ss << "Array";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeStruct ) {
-    ss << "Struct";
-  }
-  else if ( value.getType() == XmlRpc::XmlRpcValue::TypeInvalid ) {
-    ss << "Invalid";
-  }
-  else {
-    ss << "Other";
-  }
-  return ss.str();
-}
-
 bool getSubscriberNodes(V_string& sub_nodes, const std::string topic)
 {
   XmlRpc::XmlRpcValue args, result, payload;
@@ -226,10 +185,9 @@ bool getSubscriberNodes(V_string& sub_nodes, const std::string topic)
   S_string node_set;
   {
     if ( payload.size() != 3 ) {
-      printf( "Expected payload size = 3 (actual is %d)\n", payload.size() );
-      std::cout << "  type: " << XmlRpcValueType( payload ) << std::endl << std::flush;
       return false;
     }
+    //TODO Explain what we are doing
     for (int j = 0; j < payload[1].size(); ++j)
     {
       std::string t = payload[1][j][0];
@@ -243,9 +201,7 @@ bool getSubscriberNodes(V_string& sub_nodes, const std::string topic)
       }
     }
   }
-
   sub_nodes.insert(sub_nodes.end(), node_set.begin(), node_set.end());
-
   return true;
 }
 
@@ -264,8 +220,6 @@ bool getSubscriberHosts(V_string& sub_hosts, const std::string topic)
       return false;
     }
     if ( payload.getType() != XmlRpc::XmlRpcValue::TypeString ) {
-      printf( "Expected payload to be string\n" );
-      std::cout << "  type: " << XmlRpcValueType( payload ) << std::endl << std::flush;
       return false;
     }
     std::string uri = payload;
@@ -273,12 +227,10 @@ bool getSubscriberHosts(V_string& sub_hosts, const std::string topic)
     uint32_t port;
     // Split URI into
     if (!network::splitURI(uri, host, port)) {
+      //TODO we probably want to fail silently like everywhere else ?
       ROS_FATAL( "Couldn't parse the URI [%s] into a host:port pair.", uri.c_str());
       ROS_BREAK();
     }
-    //else { 
-    //  printf( "[xmlrpc_cpp]    %s -> %s : %d\n", uri.c_str(), host.c_str(), port );
-    //}
     host_set.insert( host );
   }
   sub_hosts.insert( sub_hosts.end(), host_set.begin(), host_set.end() );

--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -177,17 +177,19 @@ bool getSubscriberNodes(V_string& sub_nodes, const std::string topic)
   XmlRpc::XmlRpcValue args, result, payload;
   args[0] = this_node::getName();
 
+  // probe master to get the system state 
   if (!execute("getSystemState", args, result, payload, true))
   {
     return false;
   }
 
+  // parse the system state to determine which nodes are allowed to subscribe to topic
   S_string node_set;
   {
     if ( payload.size() != 3 ) {
       return false;
     }
-    //TODO Explain what we are doing
+    // check the subscribers for topic 
     for (int j = 0; j < payload[1].size(); ++j)
     {
       std::string t = payload[1][j][0];
@@ -210,6 +212,7 @@ bool getSubscriberHosts(V_string& sub_hosts, const std::string topic)
   V_string sub_nodes;
   getSubscriberNodes( sub_nodes, topic );
 
+  // convert list of subscriber nodes to subscriber IP addresses
   S_string host_set;
   for ( size_t i = 0; i < sub_nodes.size(); i++ ) {
     XmlRpc::XmlRpcValue args, result, payload;
@@ -227,9 +230,8 @@ bool getSubscriberHosts(V_string& sub_hosts, const std::string topic)
     uint32_t port;
     // Split URI into
     if (!network::splitURI(uri, host, port)) {
-      //TODO we probably want to fail silently like everywhere else ?
-      ROS_FATAL( "Couldn't parse the URI [%s] into a host:port pair.", uri.c_str());
-      ROS_BREAK();
+      ROS_WARN( "Couldn't parse the URI [%s] into a host:port pair.", uri.c_str());
+      continue;
     }
     host_set.insert( host );
   }
@@ -248,6 +250,7 @@ bool getServiceClients(V_string& sub_hosts, const std::string service)
     return false;
   }
 
+  // get list of authorized service providers' IP address
   for ( int j = 0; j < payload.size(); ++j ) {
     std::string ip_address = payload[j];
     sub_hosts.push_back( ip_address );

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -799,13 +799,6 @@ void update(const std::string& key, const XmlRpc::XmlRpcValue& v)
   invalidateParentParams(clean_key);
 }
 
-void paramUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
-{
-  (void)params;
-  result = xmlrpc::responseInt(0, "Deprecated function", 0);
-  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
-}
-
 void paramUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info )
 {
   std::string caller_id( params[0] );
@@ -890,7 +883,8 @@ void init(const M_string& remappings)
     }
   }
 
-  XMLRPCManager::instance()->bind("paramUpdate", static_cast<void (*)(XmlRpc::XmlRpcValue& , XmlRpc::XmlRpcValue& , XmlRpc::XmlRpcClientInfo& )>(&paramUpdateCallback) );
+  XMLRPCManager::instance()->bind("paramUpdate", paramUpdateCallback);
+
 }
 
 } // namespace param

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -811,7 +811,7 @@ void paramUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& resul
   std::string caller_id( params[0] );
   std::string param_key( params[1] );
   if ( !is_uri_match( ros::master::getURI(), client_info.ip ) ) {
-    ROS_WARN_NAMED( AUTH, "paramUpdate( %s, %s, %s ) not authorized", caller_id.c_str(), param_key.c_str(), client_info.ip.c_str() );
+    ROS_WARN_NAMED(AUTH_LOG_NAME, "paramUpdate( %s, %s, %s ) not authorized", caller_id.c_str(), param_key.c_str(), client_info.ip.c_str() );
     result = xmlrpc::responseInt(-1, "method not authorized", 0);
     return;
   }

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -884,7 +884,6 @@ void init(const M_string& remappings)
   }
 
   XMLRPCManager::instance()->bind("paramUpdate", paramUpdateCallback);
-
 }
 
 } // namespace param

--- a/clients/roscpp/src/libros/service_client_link.cpp
+++ b/clients/roscpp/src/libros/service_client_link.cpp
@@ -93,9 +93,9 @@ bool ServiceClientLink::handleHeader(const Header& header)
   }
   // check again if the client request is authorized
   std::string client_ip_address = uri_to_ip_address( connection_->getClientURI() );
-  ROS_INFO_NAMED( AUTH, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
+  ROS_INFO_NAMED(AUTH_LOG_NAME, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
   if ( !is_requester_authorized( service, client_ip_address ) ) {
-    ROS_WARN_NAMED( AUTH, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
+    ROS_WARN_NAMED(AUTH_LOG_NAME, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
     std::string msg( "Client [" + client_callerid + "] wants service connection for " + service + ", but " + client_ip_address + " is not authorized" );
     connection_->sendHeaderError( msg );
 

--- a/clients/roscpp/src/libros/service_client_link.cpp
+++ b/clients/roscpp/src/libros/service_client_link.cpp
@@ -43,6 +43,8 @@
 
 #include <boost/bind.hpp>
 
+#include "ros/topic_manager.h"
+
 namespace ros
 {
 
@@ -86,6 +88,16 @@ bool ServiceClientLink::handleHeader(const Header& header)
 
     ROS_ERROR("%s", msg.c_str());
     connection_->sendHeaderError(msg);
+
+    return false;
+  }
+  // check again if the client request is authorized
+  std::string client_ip_address = uri_to_ip_address( connection_->getClientURI() );
+  ROS_INFO_NAMED( AUTH, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
+  if ( !is_requester_authorized( service, client_ip_address ) ) {
+    ROS_WARN_NAMED( AUTH, "received service connection for %s from %s (%s)", service.c_str(), client_callerid.c_str(), client_ip_address.c_str()  );
+    std::string msg( "Client [" + client_callerid + "] wants service connection for " + service + ", but " + client_ip_address + " is not authorized" );
+    connection_->sendHeaderError( msg );
 
     return false;
   }

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -40,6 +40,7 @@
 #include "ros/init.h"
 #include "ros/file_log.h"
 #include "ros/subscribe_options.h"
+#include "ros/url.h"
 
 #include "xmlrpcpp/XmlRpc.h"
 
@@ -53,6 +54,47 @@ using namespace std; // sigh
 namespace ros
 {
 
+bool is_subscriber_authorized( const std::string& topic, const std::string& client_ip_address ) {
+  V_string sub_hosts;
+  master::getSubscriberHosts( sub_hosts, topic );
+  ROS_DEBUG_NAMED( AUTH, "Checking subscribers for %s (%zu hosts)", topic.c_str(), sub_hosts.size() );
+  std::string hosts_str;
+  for ( size_t i = 0; i < sub_hosts.size(); i++ ) {
+    ROS_DEBUG_NAMED( AUTH, "- matching %s to %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
+    if ( is_uri_match( sub_hosts[i], client_ip_address ) ) {
+      ROS_INFO_NAMED( AUTH, "IP address (%s) matches authorized subscriber %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
+      return true;
+    }
+    if ( i > 0 ) {
+      hosts_str += ", ";
+    }
+    hosts_str += sub_hosts[i];
+  }
+  ROS_WARN_NAMED( AUTH, "IP address (%s) does not match any subscribers [%s]", client_ip_address.c_str(), hosts_str.c_str() );
+
+  return false;
+}
+
+bool is_requester_authorized( const std::string& service, const std::string& client_ip_address ) {
+  V_string auth_ip_addresses;
+  std::string auth_list( "[" );
+  master::getServiceClients( auth_ip_addresses, service );
+  for ( size_t i = 0; i < auth_ip_addresses.size(); i++ ) {
+    if ( i > 0 ) {
+      auth_list += ", ";
+    }
+    auth_list += auth_ip_addresses[i];
+    if ( client_ip_address == auth_ip_addresses[i] ) {
+      ROS_INFO_NAMED( AUTH, "is_requester_authorized( %s, %s ) OK", service.c_str(), client_ip_address.c_str() );
+      return true;
+    }
+  }
+  ROS_WARN_NAMED( AUTH, "is_requester_authorized( %s, %s ) not authorized. Authorized list is %s", service.c_str(), client_ip_address.c_str(), auth_list.c_str() );
+  return true;
+}
+
+TopicManagerPtr g_topic_manager;
+boost::mutex g_topic_manager_mutex;
 const TopicManagerPtr& TopicManager::instance()
 {
   static TopicManagerPtr topic_manager = boost::make_shared<TopicManager>();
@@ -78,8 +120,8 @@ void TopicManager::start()
   connection_manager_ = ConnectionManager::instance();
   xmlrpc_manager_ = XMLRPCManager::instance();
 
-  xmlrpc_manager_->bind("publisherUpdate", boost::bind(&TopicManager::pubUpdateCallback, this, _1, _2));
-  xmlrpc_manager_->bind("requestTopic", boost::bind(&TopicManager::requestTopicCallback, this, _1, _2));
+  xmlrpc_manager_->bind("publisherUpdate", boost::bind(&TopicManager::pubUpdateCallback, this, _1, _2, _3));
+  xmlrpc_manager_->bind("requestTopic", boost::bind(&TopicManager::requestTopicCallback, this, _1, _2, _3));
   xmlrpc_manager_->bind("getBusStats", boost::bind(&TopicManager::getBusStatsCallback, this, _1, _2));
   xmlrpc_manager_->bind("getBusInfo", boost::bind(&TopicManager::getBusInfoCallback, this, _1, _2));
   xmlrpc_manager_->bind("getSubscriptions", boost::bind(&TopicManager::getSubscriptionsCallback, this, _1, _2));
@@ -1004,25 +1046,54 @@ extern std::string console::g_last_error_message;
 
 void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
 {
-  std::vector<std::string> pubs;
-  for (int idx = 0; idx < params[2].size(); idx++)
-  {
-    pubs.push_back(params[2][idx]);
+  (void)params;
+  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
+  result = xmlrpc::responseInt(0, "Deprecated function call", 0);
+}
+
+void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info)
+{
+  std::string caller_id( params[0] );
+  std::string topic( params[1] );
+  if ( !is_uri_match( ros::master::getURI(), client_info.ip ) ) {
+    ROS_WARN_NAMED( AUTH, "publisherUpdate( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    result = xmlrpc::responseInt(-1, "method not authorized", 0);
   }
-  if (pubUpdate(params[1], pubs))
-  {
-    result = xmlrpc::responseInt(1, "", 0);
-  }
-  else
-  {
-    result = xmlrpc::responseInt(0, console::g_last_error_message, 0);
+  else {
+    ROS_INFO_NAMED( AUTH, "publisherUpdate( %s, %s, %s ) OK", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    std::vector<std::string> pubs;
+    for (int idx = 0; idx < params[2].size(); idx++)
+    {
+      pubs.push_back(params[2][idx]);
+    }
+    if (pubUpdate(params[1], pubs))
+    {
+      result = xmlrpc::responseInt(1, "", 0);
+    }
+    else
+    {
+      result = xmlrpc::responseInt(0, console::g_last_error_message, 0);
+    }
   }
 }
 
 void TopicManager::requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
 {
-  if (!requestTopic(params[1], params[2], result))
-  {
+  (void)params;
+  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
+  result = xmlrpc::responseInt(0, "Deprecated function call", 0);
+}
+
+void TopicManager::requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info)
+{
+  std::string caller_id( params[0] );
+  std::string topic( params[1] );
+  if ( !is_subscriber_authorized( topic, client_info.ip ) ) {
+    ROS_WARN_NAMED( AUTH, "requestTopic( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    result = xmlrpc::responseInt(-1, "method not authorized", 0);
+    return;
+  }
+  if (!requestTopic(params[1], params[2], result)) {
     result = xmlrpc::responseInt(0, console::g_last_error_message, 0);
   }
 }

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -57,12 +57,12 @@ namespace ros
 bool is_subscriber_authorized( const std::string& topic, const std::string& client_ip_address ) {
   V_string sub_hosts;
   master::getSubscriberHosts( sub_hosts, topic );
-  ROS_DEBUG_NAMED( AUTH, "Checking subscribers for %s (%zu hosts)", topic.c_str(), sub_hosts.size() );
+  ROS_DEBUG_NAMED(AUTH_LOG_NAME, "Checking subscribers for %s (%zu hosts)", topic.c_str(), sub_hosts.size() );
   std::string hosts_str;
   for ( size_t i = 0; i < sub_hosts.size(); i++ ) {
-    ROS_DEBUG_NAMED( AUTH, "- matching %s to %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
+    ROS_DEBUG_NAMED(AUTH_LOG_NAME, "- matching %s to %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
     if ( is_uri_match( sub_hosts[i], client_ip_address ) ) {
-      ROS_INFO_NAMED( AUTH, "IP address (%s) matches authorized subscriber %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
+      ROS_INFO_NAMED(AUTH_LOG_NAME, "IP address (%s) matches authorized subscriber %s", client_ip_address.c_str(), sub_hosts[i].c_str() );
       return true;
     }
     if ( i > 0 ) {
@@ -70,7 +70,7 @@ bool is_subscriber_authorized( const std::string& topic, const std::string& clie
     }
     hosts_str += sub_hosts[i];
   }
-  ROS_WARN_NAMED( AUTH, "IP address (%s) does not match any subscribers [%s]", client_ip_address.c_str(), hosts_str.c_str() );
+  ROS_WARN_NAMED(AUTH_LOG_NAME, "IP address (%s) does not match any subscribers [%s]", client_ip_address.c_str(), hosts_str.c_str() );
 
   return false;
 }
@@ -85,11 +85,11 @@ bool is_requester_authorized( const std::string& service, const std::string& cli
     }
     auth_list += auth_ip_addresses[i];
     if ( client_ip_address == auth_ip_addresses[i] ) {
-      ROS_INFO_NAMED( AUTH, "is_requester_authorized( %s, %s ) OK", service.c_str(), client_ip_address.c_str() );
+      ROS_INFO_NAMED(AUTH_LOG_NAME, "is_requester_authorized( %s, %s ) OK", service.c_str(), client_ip_address.c_str() );
       return true;
     }
   }
-  ROS_WARN_NAMED( AUTH, "is_requester_authorized( %s, %s ) not authorized. Authorized list is %s", service.c_str(), client_ip_address.c_str(), auth_list.c_str() );
+  ROS_WARN_NAMED(AUTH_LOG_NAME, "is_requester_authorized( %s, %s ) not authorized. Authorized list is %s", service.c_str(), client_ip_address.c_str(), auth_list.c_str() );
   return true;
 }
 
@@ -1056,11 +1056,11 @@ void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpc
   std::string caller_id( params[0] );
   std::string topic( params[1] );
   if ( !is_uri_match( ros::master::getURI(), client_info.ip ) ) {
-    ROS_WARN_NAMED( AUTH, "publisherUpdate( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    ROS_WARN_NAMED(AUTH_LOG_NAME, "publisherUpdate( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
     result = xmlrpc::responseInt(-1, "method not authorized", 0);
   }
   else {
-    ROS_INFO_NAMED( AUTH, "publisherUpdate( %s, %s, %s ) OK", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    ROS_INFO_NAMED(AUTH_LOG_NAME, "publisherUpdate( %s, %s, %s ) OK", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
     std::vector<std::string> pubs;
     for (int idx = 0; idx < params[2].size(); idx++)
     {
@@ -1089,7 +1089,7 @@ void TopicManager::requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::Xml
   std::string caller_id( params[0] );
   std::string topic( params[1] );
   if ( !is_subscriber_authorized( topic, client_info.ip ) ) {
-    ROS_WARN_NAMED( AUTH, "requestTopic( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
+    ROS_WARN_NAMED(AUTH_LOG_NAME, "requestTopic( %s, %s, %s ) not authorized", caller_id.c_str(), topic.c_str(), client_info.ip.c_str() );
     result = xmlrpc::responseInt(-1, "method not authorized", 0);
     return;
   }

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -1044,13 +1044,6 @@ void TopicManager::getPublications(XmlRpcValue &pubs)
 
 extern std::string console::g_last_error_message;
 
-void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
-{
-  (void)params;
-  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
-  result = xmlrpc::responseInt(0, "Deprecated function call", 0);
-}
-
 void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info)
 {
   std::string caller_id( params[0] );
@@ -1075,13 +1068,6 @@ void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpc
       result = xmlrpc::responseInt(0, console::g_last_error_message, 0);
     }
   }
-}
-
-void TopicManager::requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
-{
-  (void)params;
-  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
-  result = xmlrpc::responseInt(0, "Deprecated function call", 0);
 }
 
 void TopicManager::requestTopicCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result, XmlRpc::XmlRpcClientInfo& client_info)

--- a/clients/roscpp/src/libros/url.cpp
+++ b/clients/roscpp/src/libros/url.cpp
@@ -15,6 +15,7 @@
 #include <arpa/inet.h>
 
 #include "ros/url.h"
+#include "ros/ros.h"
 
 using namespace std;
 
@@ -31,6 +32,7 @@ bool is_uri_match( const std::string uri, const std::string ip_address ) {
 
 URLParser::URLParser(const string url_s) 
   : url_( url_s )
+  , ip_address_( "0.0.0.0" )
 {
   this->parse(url_s);
 }
@@ -109,8 +111,8 @@ void URLParser::parse(const string& url_s)
 
     int err = getaddrinfo(host_.c_str(), NULL, &hints, &res);
     if (err != 0) {
-      //TODO we should actually fail. otherwise we will be in strange state no?
-      printf("getaddrinfo: %s\n", gai_strerror(err));
+      ROS_WARN( "Unable to parse hostname: %s", host_.c_str() );
+      ip_address_ = std::string( "0.0.0.0" );
     }
     else {
       char addrstr[100];

--- a/clients/roscpp/src/libros/url.cpp
+++ b/clients/roscpp/src/libros/url.cpp
@@ -32,7 +32,6 @@ bool is_uri_match( const std::string uri, const std::string ip_address ) {
 URLParser::URLParser(const string url_s) 
   : url_( url_s )
 {
-  //cout << "parsing " << url_s << std::endl;
   this->parse(url_s);
 }
 
@@ -44,19 +43,15 @@ std::string URLParser::get_host( ) {
   return host_;
 }
 
+/// An ip_address is considered local if it is 127.*.*.* or 169.254.*.*
 bool is_local( const std::string ip_address ) {
   struct sockaddr_in addr;
   inet_aton( ip_address.c_str(), &addr.sin_addr );
-  //int addr_3 = ( addr.sin_addr.s_addr & 0xff000000 ) >> 24;
-  //int addr_2 = ( addr.sin_addr.s_addr & 0x00ff0000 ) >> 16;
   int addr_1 = ( addr.sin_addr.s_addr & 0x0000ff00 ) >> 8;
   int addr_0 = ( addr.sin_addr.s_addr & 0x000000ff );
   if ( addr_0 == 127 || ( addr_0 == 169 && addr_1 == 254 ) ) {
-    //std::cout << ip_address << ": " << addr_0 << "." << addr_1 << "." << addr_2 << "." << addr_3 << std::endl;
-    //std::cout << ip_address << " is local address!" << std::endl;
     return true;
   }
-  //std::cout << ip_address << " is not local address!" << std::endl;
   return false;
 }
 
@@ -114,6 +109,7 @@ void URLParser::parse(const string& url_s)
 
     int err = getaddrinfo(host_.c_str(), NULL, &hints, &res);
     if (err != 0) {
+      //TODO we should actually fail. otherwise we will be in strange state no?
       printf("getaddrinfo: %s\n", gai_strerror(err));
     }
     else {

--- a/clients/roscpp/src/libros/url.cpp
+++ b/clients/roscpp/src/libros/url.cpp
@@ -1,0 +1,138 @@
+#include <string>
+#include <algorithm>
+#include <iostream>
+#include <functional>
+#include <cctype>
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include <sys/param.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "ros/url.h"
+
+using namespace std;
+
+std::string uri_to_ip_address( const std::string uri ) {
+  URLParser uri_parser( uri );
+  std::string ip_address = uri_parser.get_ip_address();
+  return ip_address;
+}
+
+bool is_uri_match( const std::string uri, const std::string ip_address ) {
+  URLParser uri_parser( uri );
+  return uri_parser.match( ip_address );
+}
+
+URLParser::URLParser(const string url_s) 
+  : url_( url_s )
+{
+  //cout << "parsing " << url_s << std::endl;
+  this->parse(url_s);
+}
+
+URLParser::~URLParser()
+{
+}
+
+std::string URLParser::get_host( ) {
+  return host_;
+}
+
+bool is_local( const std::string ip_address ) {
+  struct sockaddr_in addr;
+  inet_aton( ip_address.c_str(), &addr.sin_addr );
+  //int addr_3 = ( addr.sin_addr.s_addr & 0xff000000 ) >> 24;
+  //int addr_2 = ( addr.sin_addr.s_addr & 0x00ff0000 ) >> 16;
+  int addr_1 = ( addr.sin_addr.s_addr & 0x0000ff00 ) >> 8;
+  int addr_0 = ( addr.sin_addr.s_addr & 0x000000ff );
+  if ( addr_0 == 127 || ( addr_0 == 169 && addr_1 == 254 ) ) {
+    //std::cout << ip_address << ": " << addr_0 << "." << addr_1 << "." << addr_2 << "." << addr_3 << std::endl;
+    //std::cout << ip_address << " is local address!" << std::endl;
+    return true;
+  }
+  //std::cout << ip_address << " is not local address!" << std::endl;
+  return false;
+}
+
+bool URLParser::match( const string ip_address ) {
+  if ( ip_address_ == ip_address ) {
+    return true;
+  }
+  if ( is_local( ip_address ) ) {
+    return is_local( ip_address_ );
+  }
+  return false;
+}
+
+void URLParser::parse(const string& url_s)
+{
+    const string prot_end("://");
+    string::const_iterator prot_i = search(url_s.begin(), url_s.end(),
+                                           prot_end.begin(), prot_end.end());
+    if ( prot_i == url_s.end() ) {
+      prot_i = url_s.begin();
+    }
+    else {
+      protocol_.reserve(distance(url_s.begin(), prot_i));
+      transform(url_s.begin(), prot_i,
+          back_inserter(protocol_),
+          ptr_fun<int,int>(tolower)); // protocol is icase
+      advance(prot_i, prot_end.length());
+    }
+    string::const_iterator port_i = find(prot_i, url_s.end(), ':');
+    string::const_iterator path_i = find(prot_i, url_s.end(), '/');
+    if ( port_i != url_s.end() ) {
+      // port number
+      host_.reserve(distance(prot_i, port_i));
+      transform(prot_i, port_i,
+          back_inserter(host_),
+          ptr_fun<int,int>(tolower)); // host is icase
+      port_.assign(port_i+1, path_i);
+    }
+    else {
+      host_.reserve(distance(prot_i, path_i));
+      transform(prot_i, path_i, back_inserter(host_), ptr_fun<int,int>(tolower)); 
+    }
+    string::const_iterator query_i = find(path_i, url_s.end(), '?');
+    path_.assign(path_i, query_i);
+    if( query_i != url_s.end() ) {
+      ++query_i;
+    }
+    query_.assign(query_i, url_s.end());
+    // convert host to ip address
+    struct addrinfo hints, *res;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    int err = getaddrinfo(host_.c_str(), NULL, &hints, &res);
+    if (err != 0) {
+      printf("getaddrinfo: %s\n", gai_strerror(err));
+    }
+    else {
+      char addrstr[100];
+      void *ptr;
+      while (res) {
+        inet_ntop (res->ai_family, res->ai_addr->sa_data, addrstr, 100);
+
+        switch (res->ai_family) {
+          case AF_INET:
+            ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
+            break;
+          case AF_INET6:
+            ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;
+            break;
+        }
+        inet_ntop (res->ai_family, ptr, addrstr, 100);
+        ip_address_ = addrstr;
+        res = res->ai_next;
+      }
+    }
+}

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -79,7 +79,6 @@ public:
 
   void execute(XmlRpcValue &params, XmlRpcClientInfo &client_info, XmlRpcValue &result)
   {
-    //printf( "[xmlrpc_cpp] received client_info: %s\n", client_info.ip.c_str() );
     func_(params, result, client_info);
   }
 
@@ -417,22 +416,6 @@ void XMLRPCManager::removeASyncConnection(const ASyncXMLRPCConnectionPtr& conn)
   removed_connections_.insert(conn);
 }
 
-//bool XMLRPCManager::bind(const std::string& function_name, const XMLRPCFunc_deprecated& cb)
-//{
-//  boost::mutex::scoped_lock lock(functions_mutex_);
-//  if (functions_.find(function_name) != functions_.end())
-//  {
-//    return false;
-//  }
-//
-//  FunctionInfo info;
-//  info.name = function_name;
-//  info.function = cb;
-//  info.wrapper.reset(new XMLRPCCallWrapper(function_name, cb, &server_));
-//  functions_[function_name] = info;
-//
-//  return true;
-//}
 
 bool XMLRPCManager::bind(const std::string& function_name, const XMLRPCFunc& cb)
 {

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -409,7 +409,6 @@ void XMLRPCManager::removeASyncConnection(const ASyncXMLRPCConnectionPtr& conn)
   removed_connections_.insert(conn);
 }
 
-
 bool XMLRPCManager::bind(const std::string& function_name, const XMLRPCFunc& cb)
 {
   boost::mutex::scoped_lock lock(functions_mutex_);

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -77,9 +77,10 @@ public:
   , func_(cb)
   { }
 
-  void execute(XmlRpcValue &params, XmlRpcValue &result)
+  void execute(XmlRpcValue &params, XmlRpcClientInfo &client_info, XmlRpcValue &result)
   {
-    func_(params, result);
+    //printf( "[xmlrpc_cpp] received client_info: %s\n", client_info.ip.c_str() );
+    func_(params, result, client_info);
   }
 
 private:
@@ -90,6 +91,14 @@ private:
 void getPid(const XmlRpcValue& params, XmlRpcValue& result)
 {
   (void)params;
+  result = xmlrpc::responseInt(0, "Deprecated function", 0);
+  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
+}
+
+void getPid(const XmlRpcValue& params, XmlRpcValue& result, XmlRpcClientInfo& client_info)
+{
+  (void)params;
+  (void)client_info;
   result = xmlrpc::responseInt(1, "", (int)getpid());
 }
 
@@ -127,7 +136,7 @@ void XMLRPCManager::start()
 {
   shutting_down_ = false;
   port_ = 0;
-  bind("getPid", getPid);
+  bind("getPid", static_cast<void (*)(const XmlRpcValue& , XmlRpcValue& , XmlRpcClientInfo& )>(&getPid));
 
   bool bound = server_.bindAndListen(0);
   (void) bound;
@@ -407,6 +416,23 @@ void XMLRPCManager::removeASyncConnection(const ASyncXMLRPCConnectionPtr& conn)
   boost::mutex::scoped_lock lock(removed_connections_mutex_);
   removed_connections_.insert(conn);
 }
+
+//bool XMLRPCManager::bind(const std::string& function_name, const XMLRPCFunc_deprecated& cb)
+//{
+//  boost::mutex::scoped_lock lock(functions_mutex_);
+//  if (functions_.find(function_name) != functions_.end())
+//  {
+//    return false;
+//  }
+//
+//  FunctionInfo info;
+//  info.name = function_name;
+//  info.function = cb;
+//  info.wrapper.reset(new XMLRPCCallWrapper(function_name, cb, &server_));
+//  functions_[function_name] = info;
+//
+//  return true;
+//}
 
 bool XMLRPCManager::bind(const std::string& function_name, const XMLRPCFunc& cb)
 {

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -87,13 +87,6 @@ private:
   XMLRPCFunc func_;
 };
 
-void getPid(const XmlRpcValue& params, XmlRpcValue& result)
-{
-  (void)params;
-  result = xmlrpc::responseInt(0, "Deprecated function", 0);
-  std::cerr << "Deprecated function call in function " << __func__ << " in file " << __FILE__ << std::endl;
-}
-
 void getPid(const XmlRpcValue& params, XmlRpcValue& result, XmlRpcClientInfo& client_info)
 {
   (void)params;
@@ -135,7 +128,7 @@ void XMLRPCManager::start()
 {
   shutting_down_ = false;
   port_ = 0;
-  bind("getPid", static_cast<void (*)(const XmlRpcValue& , XmlRpcValue& , XmlRpcClientInfo& )>(&getPid));
+  bind("getPid", getPid);
 
   bool bound = server_.bindAndListen(0);
   (void) bound;

--- a/clients/rospy/src/rospy/impl/masterslave.py
+++ b/clients/rospy/src/rospy/impl/masterslave.py
@@ -474,6 +474,7 @@ class ROSHandler(XmlRpcHandler):
     def shutdown(self, caller_id, msg, client_ip_address = "127.0.0.1"):
         """
         Stop this server
+        Only master is authorized to call this method 
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param msg: a message describing why the node is being shutdown.
@@ -510,6 +511,7 @@ class ROSHandler(XmlRpcHandler):
     def getSubscriptions(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Retrieve a list of topics that this node subscribes to.
+        Only master is authorized to call this method 
         @param caller_id: ROS caller id    
         @type  caller_id: str
         @param client_ip_address: IP address of client making request
@@ -528,6 +530,7 @@ class ROSHandler(XmlRpcHandler):
     def getPublications(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Retrieve a list of topics that this node publishes.
+        Only master is authorized to call this method 
         @param caller_id: ROS caller id    
         @type  caller_id: str
         @param client_ip_address: IP address of client making request
@@ -617,7 +620,8 @@ class ROSHandler(XmlRpcHandler):
     @apivalidate(-1, (global_name('parameter_key'), None, is_ipv4('client_ip_address')))
     def paramUpdate(self, caller_id, parameter_key, parameter_value, client_ip_address = "127.0.0.1"):
         """
-        Callback from master of current publisher list for specified topic.
+        Callback from master to update specified parameter.
+        Only master is authorized to call this method 
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param parameter_key str: parameter name, globally resolved
@@ -644,6 +648,7 @@ class ROSHandler(XmlRpcHandler):
     def publisherUpdate(self, caller_id, topic, publishers, client_ip_address = "127.0.0.1"):
         """
         Callback from master of current publisher list for specified topic.
+        Only master is authorized to call this method 
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param topic str: topic name
@@ -673,6 +678,7 @@ class ROSHandler(XmlRpcHandler):
     def requestTopic(self, caller_id, topic, protocols, client_ip_address = "127.0.0.1"):
         """
         Publisher node API method called by a subscriber node.
+        Check if client_ip_address is authorized to subscribe to this topic.
    
         Request that source allocate a channel for communication. Subscriber provides
         a list of desired protocols for communication. Publisher returns the
@@ -694,7 +700,6 @@ class ROSHandler(XmlRpcHandler):
         empty list if there are no compatible protocols.
         @rtype: [int, str, [str, XmlRpcLegalValue*]]
         """
-        # Check if client_ip_address is authorized
         if not is_subscriber_authorized( topic, client_ip_address ):
             auth_logger.warn( "requestTopic( %s, %s, %s) topic not authorized" % 
                     ( caller_id, topic, client_ip_address ) )

--- a/clients/rospy/src/rospy/impl/masterslave.py
+++ b/clients/rospy/src/rospy/impl/masterslave.py
@@ -60,6 +60,7 @@ import threading
 import traceback
 import time
 import errno
+from rosmaster.authorization import is_uri_match
 
 try:
     #py3k
@@ -79,6 +80,13 @@ from rospy.impl.paramserver import get_param_server_cache
 from rospy.impl.registration import RegManager, get_topic_manager
 from rospy.impl.validators import non_empty, ParameterInvalid
 
+from rosmaster.validators import is_ipv4
+from rosmaster.authorization import is_uri_match
+
+# get authorization logger
+import rosmaster.authorization
+auth_logger = rosmaster.authorization.getLogger()
+
 # Return code slots
 STATUS = 0
 MSG = 1
@@ -92,7 +100,103 @@ def is_publishers_list(paramName):
 
 _logger = logging.getLogger("rospy.impl.masterslave")
 
+
 LOG_API = True
+
+def get_subscriber_list( masterUri, topic, this_caller_id ):
+    """
+    @param topic: Topic for which subscribers are requested
+    @return: list of subscribers for requested topic 
+    @rtype: list
+    """
+    # Check if subscriber is registered with master, return 0, "", [] if not
+    code, msg, result = xmlrpcapi(masterUri).getSystemState(this_caller_id)
+    for (t, subs) in result[1]:
+        if t == topic:
+            return list( n for n in subs )
+    return []
+
+
+def get_service_client_list( masterUri, service, this_caller_id ):
+    """
+    @param service: Service for which authorized clients are requested
+    @return: list of authorized clients for requested service 
+    @rtype: list
+    """
+    # Check if subscriber is registered with master, return 0, "", [] if not
+    code, msg, result = xmlrpcapi(masterUri).getServiceClients(this_caller_id, service)
+    if type( result ) == list:
+        return result 
+    return []
+
+
+def is_requester_authorized( service, client_ip_address ):
+    """ Get list of requester nodes from master for each topic.
+        For this given topic, check if the caller node is a valid node.
+        If the caller node is valid, get the URI for this node and check if this URI matches 
+        the caller IP address (client_ip_address).
+        We use the valid URI list from master for this topic and checking if the 
+        client_ip_address of the caller matches with one of the valid URIs.
+
+        @param topic: Topic for which subscriber authorization is requested
+        @param client_ip_address: Client IP address for which authorization check is requested 
+
+        @return: If client_ip_address is authorized for topic 
+        @rtype: bool
+    """
+    # TODO
+    masterUri = rosgraph.get_master_uri()
+    this_caller_id = rospy.names.get_caller_id()
+    auth_clients = get_service_client_list( masterUri, service, this_caller_id )
+    auth_logger.debug( "Getting clients for service %s: %s" % ( service, auth_clients ) )
+    if client_ip_address in auth_clients:
+        return True
+    auth_logger.warn( "is_requester_authorized( %s, %s ) not authorized" % ( service, client_ip_address ) )
+    return False
+
+
+def is_subscriber_authorized( topic, client_ip_address ):
+    """ Get list of subscriber nodes from master for each topic.
+        For this given topic, check if the caller node is a valid node.
+        If the caller node is valid, get the URI for this node and check if this URI matches 
+        the caller IP address (client_ip_address).
+        We use the valid URI list from master for this topic and checking if the 
+        client_ip_address of the caller matches with one of the valid URIs.
+
+        @param topic: Topic for which subscriber authorization is requested
+        @param client_ip_address: Client IP address for which authorization check is requested 
+
+        @return: If client_ip_address is authorized for topic 
+        @rtype: bool
+    """
+    masterUri = rosgraph.get_master_uri()
+    this_caller_id = rospy.names.get_caller_id()
+    auth_logger.debug( "Getting subscribers for topic [%s]" % topic )
+    subs = get_subscriber_list( masterUri, topic, this_caller_id )
+    auth_logger.debug( "- [%s]" % ( ','.join( '%s' % n for n in subs ) ) )
+
+    if len( subs ) == 0:
+        return False
+
+    """ We want to check if client_ip_address matches one of n (for each n in subs)
+        This node is the publisher and n is the subscriber
+    """
+    for n in subs:
+        code, msg, uri = xmlrpcapi(masterUri).lookupNode( this_caller_id, n )
+        auth_logger.debug( "lookupNode( %s, %s ) returned (code=%s, msg=%s, uri=%s)" 
+                % ( this_caller_id, n, code, msg, uri ) )
+        if code > 0:
+            if is_uri_match( uri, client_ip_address ):
+                auth_logger.info( "Subscriber %s XMLRPC URI (%s) matches client IP (%s)" % 
+                        ( n, uri, client_ip_address ) )
+                return True
+            else:
+                auth_logger.debug( "Subscriber %s XMLRPC URI (%s) does not match client IP (%s)" % 
+                        ( n, uri, client_ip_address ) )
+    auth_logger.warn( "Client (%s) not authorized for topic %s" % ( client_ip_address, topic ) )
+    return False
+
+
 
 def apivalidate(error_return_value, validators=()):
     """
@@ -291,8 +395,8 @@ class ROSHandler(XmlRpcHandler):
     ###############################################################################
     # EXTERNAL API
 
-    @apivalidate([])
-    def getBusStats(self, caller_id):
+    @apivalidate([], (is_ipv4('client_ip_address'),))
+    def getBusStats(self, caller_id, client_ip_address):
         """
         Retrieve transport/topic statistics
         @param caller_id: ROS caller id    
@@ -304,18 +408,28 @@ class ROSHandler(XmlRpcHandler):
                subConnectionData: [connectionId, bytesReceived, dropEstimate, connected]* . dropEstimate is -1 if no estimate. 
            serviceStats: not sure yet, probably akin to [numRequests, bytesReceived, bytesSent] 
         """
+        is_master = is_uri_match( self.masterUri, client_ip_address )
         pub_stats, sub_stats = get_topic_manager().get_pub_sub_stats()
         #TODO: serviceStats
-        return 1, '', [pub_stats, sub_stats, []]
+        if is_master:
+            return 1, '', [pub_stats, sub_stats, []]
+        else:
+            return -1, "Only master authorized to call getBusStats()", []
 
-    @apivalidate([])
-    def getBusInfo(self, caller_id):
+    @apivalidate([], (is_ipv4('client_ip_address'),))
+    def getBusInfo(self, caller_id, client_ip_address):
         """
         Retrieve transport/topic connection information
         @param caller_id: ROS caller id    
         @type  caller_id: str
         """
-        return 1, "bus info", get_topic_manager().get_pub_sub_info()
+        """ Only master is authorized to call this method """
+        if is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "getBusInfo( %s, %s ) method not authorized" % ( caller_id, client_ip_address ) )
+            return 1, "bus info", get_topic_manager().get_pub_sub_info()
+        else:
+            return -1, "method not authorized", []
+
     
     @apivalidate('')
     def getMasterUri(self, caller_id):
@@ -347,27 +461,27 @@ class ROSHandler(XmlRpcHandler):
                 self.protocol_handlers = None
             return True
         
-    @apivalidate(0, (None, ))
-    def shutdown(self, caller_id, msg=''):
+    @apivalidate(0, (None, is_ipv4('client_ip_address')))
+    def shutdown(self, caller_id, msg, client_ip_address):
         """
         Stop this server
         @param caller_id: ROS caller id
         @type  caller_id: str
-        @param msg: a message describing why the node is being shutdown.
+        @param msg: a message describing why the node is being shutdown. (XXX no longer an optional argument)
         @type  msg: str
         @return: [code, msg, 0]
         @rtype: [int, str, int]
         """
-        if msg:
-            print("shutdown request: %s"%msg)
-        else:
-            print("shutdown requst")
+        if not is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "shutdown( %s, '%s', %s ) method not authorized" 
+                    % ( caller_id, msg, client_ip_address ) )
+            return -1, "method not authorized", 0
         if self._shutdown('external shutdown request from [%s]: %s'%(caller_id, msg)):
             signal_shutdown('external shutdown request from [%s]: [%s]'%(caller_id, msg))
         return 1, "shutdown", 0
 
-    @apivalidate(-1)
-    def getPid(self, caller_id):
+    @apivalidate(-1, (is_ipv4('client_ip_address'),))
+    def getPid(self, caller_id, client_ip_address):
         """
         Get the PID of this server
         @param caller_id: ROS caller id
@@ -375,13 +489,17 @@ class ROSHandler(XmlRpcHandler):
         @return: [1, "", serverProcessPID]
         @rtype: [int, str, int]
         """
+        if is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "shutdown( %s, '%s', %s ) method not authorized" 
+                    % ( caller_id, msg, client_ip_address ) )
         return 1, "", os.getpid()
+
 
     ###############################################################################
     # PUB/SUB APIS
 
-    @apivalidate([])
-    def getSubscriptions(self, caller_id):
+    @apivalidate([], (is_ipv4('client_ip_address'),))
+    def getSubscriptions(self, caller_id, client_ip_address):
         """
         Retrieve a list of topics that this node subscribes to.
         @param caller_id: ROS caller id    
@@ -389,10 +507,15 @@ class ROSHandler(XmlRpcHandler):
         @return: list of topics this node subscribes to.
         @rtype: [int, str, [ [topic1, topicType1]...[topicN, topicTypeN]]]
         """
+        if not is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "getSubscriptions( %s, %s ) method not authorized" 
+                    % ( caller_id, client_ip_address ) )
+            return -1, "method not authorized", []
         return 1, "subscriptions", get_topic_manager().get_subscriptions()
 
-    @apivalidate([])
-    def getPublications(self, caller_id):
+
+    @apivalidate([], (is_ipv4('client_ip_address'),))
+    def getPublications(self, caller_id, client_ip_address):
         """
         Retrieve a list of topics that this node publishes.
         @param caller_id: ROS caller id    
@@ -400,7 +523,12 @@ class ROSHandler(XmlRpcHandler):
         @return: list of topics published by this node.
         @rtype: [int, str, [ [topic1, topicType1]...[topicN, topicTypeN]]]
         """
+        if not is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "getPublications( %s, %s ) method not authorized" 
+                    % ( caller_id, client_ip_address ) )
+            return -1, "method not authorized", []
         return 1, "publications", get_topic_manager().get_publications()
+
     
     def _connect_topic(self, topic, pub_uri): 
         """
@@ -474,8 +602,8 @@ class ROSHandler(XmlRpcHandler):
                 return h.create_transport(topic, pub_uri, result)
         return 0, "ERROR: publisher returned unsupported protocol choice: %s"%result, 0
 
-    @apivalidate(-1, (global_name('parameter_key'), None))
-    def paramUpdate(self, caller_id, parameter_key, parameter_value):
+    @apivalidate(-1, (global_name('parameter_key'), None, is_ipv4('client_ip_address')))
+    def paramUpdate(self, caller_id, parameter_key, parameter_value, client_ip_address):
         """
         Callback from master of current publisher list for specified topic.
         @param caller_id: ROS caller id
@@ -488,14 +616,18 @@ class ROSHandler(XmlRpcHandler):
         is not subscribed to parameter_key
         @rtype: [int, str, int]
         """
+        if not is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "paramUpdate( %s, %s, %s ) method not authorized" 
+                    % ( caller_id, parameter_key, client_ip_address ) )
+            return -1, "method not authorized", []
         try:
             get_param_server_cache().update(parameter_key, parameter_value)
             return 1, '', 0
         except KeyError:
             return -1, 'not subscribed', 0
 
-    @apivalidate(-1, (is_topic('topic'), is_publishers_list('publishers')))
-    def publisherUpdate(self, caller_id, topic, publishers):
+    @apivalidate(-1, (is_topic('topic'), is_publishers_list('publishers'), is_ipv4('client_ip_address')))
+    def publisherUpdate(self, caller_id, topic, publishers, client_ip_address ):
         """
         Callback from master of current publisher list for specified topic.
         @param caller_id: ROS caller id
@@ -507,14 +639,22 @@ class ROSHandler(XmlRpcHandler):
         @return: [code, status, ignore]
         @rtype: [int, str, int]
         """
+        """ Check if request is from master. if so, no need to check if publisher URI is authorized """
+        if not is_uri_match( self.masterUri, client_ip_address ):
+            auth_logger.warn( "publisherUpdate( %s, %s, %s ) method not authorized" 
+                    % ( caller_id, topic, client_ip_address ) )
+            return -1, "method not authorized", []
+        auth_logger.info( "publisherUpdate( %s, %s, %s ): OK" % 
+                ( caller_id, topic, client_ip_address ) )
+        auth_logger.debug( "  with %s" %  publishers )
         if self.reg_man:
             for uri in publishers:
                 self.reg_man.publisher_update(topic, publishers)
         return 1, "", 0
     
     _remap_table['requestTopic'] = [0] # remap topic 
-    @apivalidate([], (is_topic('topic'), non_empty('protocols')))
-    def requestTopic(self, caller_id, topic, protocols):
+    @apivalidate([], (is_topic('topic'), non_empty('protocols'), is_ipv4('client_ip_address')))
+    def requestTopic(self, caller_id, topic, protocols, client_ip_address ):
         """
         Publisher node API method called by a subscriber node.
    
@@ -536,13 +676,25 @@ class ROSHandler(XmlRpcHandler):
         empty list if there are no compatible protocols.
         @rtype: [int, str, [str, XmlRpcLegalValue*]]
         """
+        # Check if client_ip_address is authorized
+        if not is_subscriber_authorized( topic, client_ip_address ):
+            auth_logger.warn( "requestTopic( %s, %s, %s) topic not authorized" % 
+                    ( caller_id, topic, client_ip_address ) )
+            return 0, "topic not authorized", []
+        auth_logger.info( "requestTopic( %s, %s, %s) OK" % 
+                ( caller_id, topic, client_ip_address ) )
         if not get_topic_manager().has_publication(topic):
-            return -1, "Not a publisher of [%s]"%topic, []
+            return -1, "Not a publisher of [%s]" % topic, []
+
         for protocol in protocols: #simple for now: select first implementation 
             protocol_id = protocol[0]
             for h in self.protocol_handlers:
                 if h.supports(protocol_id):
                     _logger.debug("requestTopic[%s]: choosing protocol %s", topic, protocol_id)
                     return h.init_publisher(topic, protocol)
+                    #code, msg, protocol_params = h.init_publisher(topic, protocol)
+                    #print( "selecting %s" % protocol_id )
+                    #print( "%s" % "\n".join( "- %s" % ( p[0] ) for p in protocol_params ) )
+                    #return code, msg, protocol_params
         return 0, "no supported protocol implementations", []
 

--- a/clients/rospy/src/rospy/impl/masterslave.py
+++ b/clients/rospy/src/rospy/impl/masterslave.py
@@ -440,12 +440,14 @@ class ROSHandler(XmlRpcHandler):
             return -1, "method not authorized", []
 
     
-    @apivalidate('')
-    def getMasterUri(self, caller_id):
+    @apivalidate('', (is_ipv4('client_ip_address'),))
+    def getMasterUri(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Get the URI of the master node.
         @param caller_id: ROS caller id    
         @type  caller_id: str
+        @param client_ip_address: IP address of client making request
+        @type  client_ip_address: str 
         @return: [code, msg, masterUri]
         @rtype: [int, str, str]
         """
@@ -492,12 +494,14 @@ class ROSHandler(XmlRpcHandler):
             signal_shutdown('external shutdown request from [%s]: [%s]'%(caller_id, msg))
         return 1, "shutdown", 0
 
-    @apivalidate(-1)
-    def getPid(self, caller_id):
+    @apivalidate(-1, (is_ipv4('client_ip_address'),))
+    def getPid(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Get the PID of this server
         @param caller_id: ROS caller id
         @type  caller_id: str
+        @param client_ip_address: IP address of client making request
+        @type  client_ip_address: str 
         @return: [1, "", serverProcessPID]
         @rtype: [int, str, int]
         """

--- a/test/test_secure_ros/CMakeLists.txt
+++ b/test/test_secure_ros/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(test_secure_ros)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES test_secure_ros
+   CATKIN_DEPENDS roscpp std_msgs
+#  DEPENDS system_lib
+)
+
+include_directories( ${catkin_INCLUDE_DIRS} )
+
+add_executable( talker2 src/talker.cpp )
+target_link_libraries( talker2 ${catkin_LIBRARIES} )
+
+add_executable( listener2 src/listener.cpp )
+target_link_libraries( listener2 ${catkin_LIBRARIES} )
+
+add_executable( is_uri_match src/is_uri_match.cpp )
+target_link_libraries( is_uri_match ${catkin_LIBRARIES} )
+
+install(TARGETS talker2 listener2
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+catkin_install_python( PROGRAMS 
+  nodes/listener.py 
+  nodes/talker.py 
+  nodes/rosxmlrpc.py 
+  nodes/test_config.py 
+  nodes/test_self.py 
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/test/test_secure_ros/README.rst
+++ b/test/test_secure_ros/README.rst
@@ -1,0 +1,37 @@
+Test Secure ROS
+---------------
+
+This package provides some tests for Secure ROS.
+
+Requirements 
+^^^^^^^^^^^^
+::
+  sudo apt-get install python-pytest
+
+Test authorization configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This test will parse the authorization file and check for errors. 
+
+You may provide the authorization file as an argument or using the ``ROS_AUTH_FILE`` environment variable. ::
+
+  rosrun test_secure_ros test_config.py -a ros_auth.yaml
+
+Test authorization configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This test checks authorization functions based on an example configuration file ``conf/test.yaml``. ::
+
+  python -m pytest test_parameters.py
+
+
+Test Self
+^^^^^^^^^
+
+This test can be used to check if the secure ROS master correctly follows the rules provided by the authorization file. Make sure that all the nodes are running before running this test.
+
+You may then run the test as follows. ::
+
+  rosrun test_secure_ros test_self.py -a /path/to/simple_pubsub_ros_auth.yaml -I 
+
+The test will load the authorization configuration YAML file and also obtain the ROS master URI (``ROS_MASTER_URI``) and the current IP address (``ROS_IP``) from environment variables. You may provide these values if the environment variables are not set or if you wish to override them using the appropriate options. The node then calls the XMLRPC methods on the ROS master to check if the responses from the master are consistent with the rules in the authorization file.
+

--- a/test/test_secure_ros/nodes/TestAuth.py
+++ b/test/test_secure_ros/nodes/TestAuth.py
@@ -1,0 +1,22 @@
+"""
+"""
+
+from rosmaster.authorization import ROSMasterAuth
+import argparse
+import os
+import sys
+
+
+class TestAuth( ):
+  def __init__( self, auth_file ):
+    self.auth = ROSMasterAuth( auth_file )
+    for ( key, val ) in self.auth.aliases.items():
+        setattr( self, key, val[0] )
+        print( "%s: %s" % ( key, getattr( self, key ) ) )
+
+  def check_param_setter( self, param, ip, value ):
+    assert self.auth.check_param_setter( param, ip ) == value 
+
+  def check_param_getter( self, param, ip, value ):
+    assert self.auth.check_param_getter( param, ip ) == value 
+

--- a/test/test_secure_ros/nodes/conf/test.yaml
+++ b/test/test_secure_ros/nodes/conf/test.yaml
@@ -1,0 +1,21 @@
+aliases:
+  machine1: [192.168.10.201]
+  machine2: [192.168.10.202]
+  machine3: [192.168.10.203]
+topics:
+  /chatter:
+    publishers: [machine1]
+    subscribers: [machine2]
+nodes:
+  /talker: [machine1]
+  /listener: [machine2]
+parameters:
+  /abc/def:
+    setters: [machine1]
+    getters: [machine1,machine2]
+  /talker: 
+    setters: [machine1]
+    getters: [machine1]
+  /listener: 
+    setters: [machine2]
+    getters: [machine2]

--- a/test/test_secure_ros/nodes/listener.py
+++ b/test/test_secure_ros/nodes/listener.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+import rospy
+from std_msgs.msg import String, Int64
+import time
+
+chatter_count = 0
+chatter_topic = "/chatter"
+counter_count = 0
+counter_topic = "/counter"
+
+
+def chatter_callback(msg):
+  global chatter_count
+  global chatter_topic
+  chatter_count += 1
+  if chatter_count % 10 == 1:
+    rospy.loginfo( "%d. %s -> %s" % ( chatter_count, chatter_topic, msg.data ) )
+
+
+def counter_callback(msg):
+  global counter_count
+  global counter_topic
+  counter_count += 1
+  if counter_count % 10 == 1:
+    rospy.loginfo( "%d. %s -> %s" % ( counter_count, counter_topic, msg.data ) )
+
+  
+def listener( name = "listener", anon = False ):
+  rospy.init_node( name, anonymous = anon )
+  time.sleep(0.5)
+  print( "Started node %s" % rospy.get_name() )
+  global chatter_topic
+  global counter_topic
+  print( "Subscribing to %s" % ( chatter_topic ) )
+  chatter_sub = rospy.Subscriber("chatter", String, chatter_callback)
+  time.sleep(0.5)
+  print( "Subscribing to %s" % ( counter_topic ) )
+  counter_sub = rospy.Subscriber("counter", Int64, counter_callback)
+
+  rate = rospy.Rate(10.) # 1hz
+  while not rospy.is_shutdown():
+      rate.sleep()
+  counter_sub.unregister()
+  chatter_sub.unregister()
+
+if __name__ == '__main__':
+  import argparse
+  parser = argparse.ArgumentParser()
+  parser.add_argument( "--name", type = str, default = "listener", help="Node name" )
+  parser.add_argument( "--anon", action = "store_true", help="Anonymize node name" )
+  args = parser.parse_args()
+
+  listener( name = args.name, anon = args.anon )
+  time.sleep(0.5)

--- a/test/test_secure_ros/nodes/nodexmlrpc.py
+++ b/test/test_secure_ros/nodes/nodexmlrpc.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+import argparse
+import os
+import sys
+import argparse 
+import xmlrpclib
+import sys 
+from rosxmlrpc import ROSXmlRpc
+
+
+def get_node_uri( node, master_uri, caller_id = "anon" ):
+  rosxmlrpc = ROSXmlRpc( master_uri, caller_id )
+  ret, msg, node_uri = rosxmlrpc.call( "lookupNode", [node] )
+  return node_uri if ret > 0 else ""
+
+""" Utility script to call XMLRPC commands on nodes.
+    The node's XMLRPC URI is obtained from the master first.
+"""
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser( description='ROS Node XmlRpc client',
+      usage='''rosxmlrpc --node NODENAME [OPTIONS] arguments ''')
+  parser.add_argument('arguments', type = str, nargs = "*", help = 'method name followed by method arguments' )
+  parser.add_argument('--node', "-n", type = str, default = "", help = 'Node name' )
+  parser.add_argument('--caller_id', "-c", type = str, default = "anon", help = 'Caller ID' )
+  parser.add_argument('--master_uri', "-m", type = str, default = os.environ.get( "ROS_MASTER_URI" ), help = 'ROS Master URI' )
+  args = parser.parse_args()
+
+  node_uri = get_node_uri( args.node, args.master_uri )
+  if not node_uri:
+    print( "Please provide node ( --node )" )
+    sys.exit( 0 )
+
+  method_name = args.arguments[0]
+  method_args = args.arguments[1:]
+  print( "Calling: %s( caller_id, %s )" % ( method_name, ", ".join( "'%s'" % a for a in method_args ) ) )
+
+  rosxmlrpc = ROSXmlRpc( node_uri, args.caller_id )
+  rosxmlrpc.call( method_name, method_args )
+ 
+

--- a/test/test_secure_ros/nodes/rosxmlrpc.py
+++ b/test/test_secure_ros/nodes/rosxmlrpc.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+import argparse
+import os
+import sys
+import argparse 
+import xmlrpclib
+import xml
+
+
+class ROSXmlRpc( ):
+  def __init__( self, master_uri, caller_id = "anon" ):
+    self.master_uri = master_uri
+    self.caller_id = caller_id
+    self.client = xmlrpclib.ServerProxy( self.master_uri )
+
+  def call( self, method_name, method_args ):
+    if not hasattr( self.client, method_name ):
+      print( 'Unrecognized ROS XMLRPC method: %s' % method_name )
+      return
+    method = getattr( self.client, method_name )
+    ret, msg, val = method( self.caller_id, *tuple( method_args ) )
+    print( "Returned: %d" % ret )
+    print( "Message: %s" % msg )
+    if type( val ) == list:
+        print( "Value:\n%s" % "\n".join( "- %s" % v for v in val ) )
+    else:
+        print( "Value: %s" % val )
+    return ret, msg, val 
+  
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser( description='ROS Master XmlRpc client',
+      usage='''rosxmlrpc <command> [OPTIONS] [<args>]"
+
+The ROS XMLRPC commands are:
+
+  getServiceClients       Get list of authorized subscriber clients
+  getPublishedTopics      Get list of published topics
+  getSystemState          Get list of published topics
+
+''')
+  parser.add_argument('arguments', type = str, nargs = "*", help = 'Method name plus arguments' )
+  parser.add_argument('--caller_id', "-c", type = str, default = "anon", help = 'Caller ID' )
+  parser.add_argument('--master_uri', "-m", type = str, default = os.environ.get( "ROS_MASTER_URI" ), help = 'ROS Master URI' )
+  args = parser.parse_args()
+
+  method_name = args.arguments[0]
+  method_args = args.arguments[1:]
+  print( "Calling: %s( caller_id, %s )" % ( method_name, ", ".join( "'%s'" % a for a in method_args ) ) )
+
+  rosxmlrpc = ROSXmlRpc( args.master_uri, args.caller_id )
+  rosxmlrpc.call( method_name, method_args )
+ 

--- a/test/test_secure_ros/nodes/talker.py
+++ b/test/test_secure_ros/nodes/talker.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import rospy
+from std_msgs.msg import String, Int64
+import time
+
+def talker( name = "talker", anon = False ):
+  rospy.init_node( name, anonymous = anon )
+  time.sleep(0.5)
+  print( "Started node %s" % rospy.get_name() )
+  chatter_topic = "/chatter"
+  counter_topic = "/counter"
+  print( "Publishing to %s" % chatter_topic )
+  pub1 = rospy.Publisher( chatter_topic, String, queue_size=10)
+  time.sleep(0.5)
+  print( "Publishing to %s" % counter_topic )
+  pub2 = rospy.Publisher( counter_topic, Int64, queue_size=10)
+  cnt = 0
+  rate = rospy.Rate(1.) # 1hz
+  while not rospy.is_shutdown():
+    chatter_msg = "hello world %d" % ( cnt )
+    counter_msg = Int64( data = cnt )
+    if cnt % 10 == 1:
+      rospy.loginfo( "%d. %s <- %s" % ( cnt, chatter_topic, chatter_msg ) )
+    pub1.publish( chatter_msg )
+    rate.sleep()
+    if cnt % 10 == 1:
+      rospy.loginfo( "%d. %s <- %s" % ( cnt, counter_topic, counter_msg ) )
+    pub2.publish( Int64( data=cnt ) )
+    rate.sleep()
+    cnt = cnt + 1
+  print( "Finished" )
+
+if __name__ == '__main__':
+  import argparse
+  parser = argparse.ArgumentParser()
+  parser.add_argument( "--name", type = str, default = "talker", help="Node name" )
+  parser.add_argument( "--anon", action = "store_true", help="Anonymize node name" )
+  args = parser.parse_args()
+
+  try:
+    talker( name = args.name, anon = args.anon )
+  except rospy.ROSInterruptException:
+    pass
+  time.sleep(0.5)

--- a/test/test_secure_ros/nodes/test_config.py
+++ b/test/test_secure_ros/nodes/test_config.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+"""
+
+from rosmaster.authorization import ROSMasterAuth
+import argparse
+import os
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument( "--auth_file", "-a", type = str, default = os.environ.get( "ROS_AUTH_FILE" ), help="Authorization file" )
+  args = parser.parse_args()
+  if args.auth_file == "":
+    print( "Please specify ROS authorization file either using the -a option." )
+  elif os.path.exists( args.auth_file ):
+    print( "Loading %s" % args.auth_file )
+    auth = ROSMasterAuth( args.auth_file )
+  else:
+    print( "ROS authorization file (%s) does not exist!" % args.auth_file )

--- a/test/test_secure_ros/nodes/test_parameters.py
+++ b/test/test_secure_ros/nodes/test_parameters.py
@@ -1,0 +1,56 @@
+"""
+"""
+
+import TestAuth 
+
+def test_setters( ):
+  auth = TestAuth.TestAuth( "conf/test.yaml" )
+  auth.check_param_setter( "/talker", auth.machine1, True )
+  auth.check_param_setter( "/talker", auth.machine2, False )
+  auth.check_param_setter( "/talker", auth.machine3, False )
+  auth.check_param_setter( "/listener", auth.machine1, False )
+  auth.check_param_setter( "/listener", auth.machine2, True )
+  auth.check_param_setter( "/listener", auth.machine3, False )
+  auth.check_param_setter( "/abc/def", auth.machine1, True )
+  auth.check_param_setter( "/abc/def", auth.machine2, False )
+  auth.check_param_setter( "/abc/def", auth.machine3, False )
+
+def test_getters( ):
+  auth = TestAuth.TestAuth( "conf/test.yaml" )
+  auth.check_param_getter( "/talker", auth.machine1, True )
+  auth.check_param_getter( "/talker", auth.machine2, False )
+  auth.check_param_getter( "/talker", auth.machine3, False )
+  auth.check_param_getter( "/listener", auth.machine1, False )
+  auth.check_param_getter( "/listener", auth.machine2, True )
+  auth.check_param_getter( "/listener", auth.machine3, False )
+  auth.check_param_getter( "/abc/def", auth.machine1, True )
+  auth.check_param_getter( "/abc/def", auth.machine2, True )
+  auth.check_param_getter( "/abc/def", auth.machine3, False )
+
+
+def test_prefix_setters( ):
+  auth = TestAuth.TestAuth( "conf/test.yaml" )
+  auth.check_param_setter( "/talker/a", auth.machine1, True )
+  auth.check_param_setter( "/talker/a", auth.machine2, False )
+  auth.check_param_setter( "/talker/listener", auth.machine1, True )
+  auth.check_param_setter( "/talker/listener", auth.machine2, False )
+
+  auth.check_param_setter( "/abc", auth.machine1, True )
+  auth.check_param_setter( "/abc", auth.machine2, True )
+
+  auth.check_param_setter( "/abc/def/g", auth.machine1, True )
+  auth.check_param_setter( "/abc/def/g", auth.machine2, False )
+
+
+def test_prefix_getters( ):
+  auth = TestAuth.TestAuth( "conf/test.yaml" )
+  auth.check_param_getter( "/talker/a", auth.machine1, True )
+  auth.check_param_getter( "/talker/a", auth.machine2, False )
+  auth.check_param_getter( "/talker/listener", auth.machine1, True )
+  auth.check_param_getter( "/talker/listener", auth.machine2, False )
+
+  auth.check_param_getter( "/abc", auth.machine1, True )
+  auth.check_param_getter( "/abc", auth.machine2, True )
+
+  auth.check_param_getter( "/abc/def/g", auth.machine1, True )
+  auth.check_param_getter( "/abc/def/g", auth.machine2, True )

--- a/test/test_secure_ros/nodes/test_self.py
+++ b/test/test_secure_ros/nodes/test_self.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+"""
+Read in an authorization file and test Secure ROS implementation by probing master.
+The assumption is that all nodes are running.
+"""
+
+from rosmaster.authorization import ROSMasterAuth
+import xmlrpclib
+import logging
+import sys
+import os
+import argparse
+
+def getLogger( ):
+  """ Create test logger
+  """
+  if getLogger.logger == None:
+    formatter = logging.Formatter('[test][%(levelname)s] %(message)s')
+    handler = logging.StreamHandler( )
+    handler.setFormatter( formatter )
+    handler.setLevel( logging.INFO )
+    getLogger.logger = logging.getLogger( "test" )
+    getLogger.logger.setLevel( logging.DEBUG )
+    getLogger.logger.addHandler( handler )
+  return getLogger.logger
+
+getLogger.logger = None
+
+
+def get_authorized( ip_addr, auth_file ):
+  """ Create list of authorized topics, services, etc 
+      This is done outside the rosmaster.authorization module as an independent test
+      (It uses rosmaster.authorization to parse the YAML file)
+  """
+  print( "Checking authorization for %s" % ip_addr )
+  auth_list = {}
+  auth = ROSMasterAuth( auth_file, is_master = False )
+  auth_file2 = "auth.yaml" 
+  getLogger().info( "Saving authorization configuration to %s" % auth_file2 )
+  auth.save( auth_file2 )
+  auth_list["published_topics"] = set( t for (t,ip_set) in auth.publishers.items() if ip_addr in ip_set )
+  auth_list["subscribed_topics"] = set( t for (t,ip_set) in auth.subscribers.items() if ip_addr in ip_set )
+  auth_list["state"] = { }
+  auth_list["state"]["published_topics"] = set( t for (t,ip_set) in auth.publishers.items() if ip_addr in ip_set )
+  auth_list["state"]["subscribed_topics"] = set( t for (t,ip_set) in auth.subscribers.items() if ip_addr in ip_set )
+  auth_list["state"]["published_topics"] -= {"/rosout_agg"}
+
+  return auth_list
+
+
+
+class Tester():
+  def __init__( self, master_uri, ip_addr, auth_file ):
+    self.logger = getLogger()
+    self.logger.info( "ROS Master: %s" % master_uri )
+    self.logger.info( "IP addr: %s" % ip_addr )
+    self.logger.info( "Authorization configuration file: %s" % auth_file )
+    self.results = {}
+    self.master_uri = master_uri
+    self.ip_addr = ip_addr
+    self.auth_list = get_authorized( ip_addr, auth_file )
+    self.client = xmlrpclib.ServerProxy( self.master_uri )
+    self.caller_id = "tester" 
+
+
+  def call( self, method_name, args ):
+    method = getattr( self.client, method_name )
+    self.logger.debug( "%s( %s )" % ( method_name, ", ".join( "'%s'" % a for a in args ) ) )
+    retval = method( *args )
+    return retval
+
+
+  def test_method( self, method_name, args = tuple() ):
+    """ Call XMLRPC method_name with value
+    """
+    args = (self.caller_id,) + tuple(args)
+    ret, msg, val = self.call( method_name, args )
+    if ret != 1:
+      self.logger.warn( "%s: Call Failed (%s, %s)" % ( method_name, ret, msg ) )
+    else:
+      self.logger.debug( "%s: Call OK" % method_name )
+    return val 
+
+
+  def check_test_equal( self, method, actual_value, reference_value, value_name ):
+    """ Check if actual_value == reference_value 
+    """
+    name = "%s_%s_equal" % ( method, value_name )
+    self.results[name] = 0
+    if actual_value == reference_value:
+      self.results[name] = 1
+      self.logger.debug( "%s: OK" % method )
+    else:
+      self.logger.warn( "%s: Failed. %s: %s (reference: %s)" % ( method, 
+        value_name, actual_value, reference_value ) )
+    return self.results[name]
+
+
+  def print_results( self ):
+    total = len( self.results )
+    success = sum( v for k, v in self.results.items() )
+    self.logger.info( "===" )
+    self.logger.info( "Successful: %d/ %d" % ( success, total ) )
+
+  def test_topics( self ):
+    """ """
+    self.logger.info( "-- Testing topics --" )
+
+    #method = "lookupNode"
+    #val = self.test_method( method, ("",) )
+    #topics = set( v[0] for v in val )
+    #self.check_test_equal( method, topics, self.auth_list.topics["topics"], )
+
+    """ """
+    method = "getPublishedTopics"
+    val = self.test_method( method, ("",) )
+    topics = set( v[0] for v in val )
+    self.check_test_equal( method, topics, self.auth_list["subscribed_topics"], "topics" )
+
+    """ """
+    method = "getTopicTypes"
+    val = self.test_method( method )
+    topics = set( v[0] for v in val )
+    self.check_test_equal( method, topics, self.auth_list["subscribed_topics"], "topics" )
+
+    """ """
+    success = True
+    method = "getSystemState"
+    publishers, subscribers, services = self.test_method( method )
+    sub_topics = set( v[0] for v in subscribers )
+    self.check_test_equal( method, sub_topics, self.auth_list["state"]["published_topics"], "published_topics" )
+    pub_topics = set( v[0] for v in publishers )
+    self.check_test_equal( method, pub_topics, self.auth_list["state"]["subscribed_topics"], "subscribed_topics" )
+    """ """
+
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument( "--auth_file", "-a", type = str, default = os.environ.get( "ROS_AUTH_FILE" ), help="Authorization file" )
+  parser.add_argument( "--master_uri", "-M", type = str, default = os.environ.get( "ROS_MASTER_URI" ), help = 'Master URI' )
+  parser.add_argument( "--ip_addr", "-I", type = str, default = os.environ.get( "ROS_IP" ), help = 'IP address' )
+  args = parser.parse_args()
+  if args.ip_addr == None:
+    print( "Unable to obtain IP address. Please use the -I option to specify IP address of this machine." )
+    exit()
+  if args.auth_file == None:
+    print( "Unable to obtain authorization file. Please use the -a option to specify configuration file." )
+    exit()
+  elif not os.path.exists( args.auth_file ):
+    print( "Authorization file (%s) does not exist. Please use the -a option to specify configuration file." % args.auth_file )
+    exit()
+
+  auth_file = os.path.realpath( args.auth_file )
+  tester = Tester( args.master_uri, args.ip_addr, auth_file )
+  tester.test_topics()
+  tester.print_results()
+

--- a/test/test_secure_ros/package.xml
+++ b/test/test_secure_ros/package.xml
@@ -1,0 +1,17 @@
+<package>
+  <name>test_secure_ros</name>
+  <version>1.11.20</version>
+  <description>
+    A package containing nodes to test Secure ROS features.
+  </description>
+  <maintainer email="aravind@ai.sri.com">Aravind Sundaresan</maintainer>
+  <license>BSD</license>
+  <author email="aravind@ai.sri.com">Aravind Sundaresan</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+</package>

--- a/test/test_secure_ros/src/is_uri_match.cpp
+++ b/test/test_secure_ros/src/is_uri_match.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017, SRI International
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <cstdio>
+#include <netdb.h>
+#include <sys/param.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "ros/url.h"
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		printf("Usage: %s <URI> [IP address]\n", argv[0]);
+		return 0;
+	}
+  URLParser uri( argv[1] );
+  std::cout << argv[1];
+  std::cout << ": host= " << uri.get_host();
+  std::cout << ", ip address= " << uri.get_ip_address();
+  std::cout << ", port= " << uri.get_port();
+  std::cout << ", protocol= " << uri.get_protocol() << std::endl;
+
+  if ( argc >= 3 ) {
+    std::cout << "is_uri_match( " << argv[1] << ", " << argv[2] << " ): " ;
+    std::cout << ( is_uri_match( argv[1], argv[2] ) ? "OK" : "No" ) << std::endl;
+  }
+
+	return 0;
+}

--- a/test/test_secure_ros/src/listener.cpp
+++ b/test/test_secure_ros/src/listener.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017, SRI International
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+#include "std_msgs/Int64.h"
+
+std::string counter_topic( "/counter" );
+std::string chatter_topic( "/chatter" );
+
+void counter_cb( const std_msgs::Int64::ConstPtr& msg )
+{
+  static int count( 0 );
+  if ( count++ % 10 == 1 ) {
+    ROS_INFO( "%d. %s -> %ld", count, counter_topic.c_str(), msg->data );
+  }
+}
+
+void chatter_cb( const std_msgs::String::ConstPtr& msg )
+{
+  static int count( 0 );
+  if ( count++ % 10 == 1 ) {
+    ROS_INFO( "%d. %s -> %s", count, counter_topic.c_str(), msg->data.c_str() );
+  }
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "listener");
+  ros::NodeHandle n;
+  ros::Rate loop_rate(1);
+
+  loop_rate.sleep();
+  std::cout << "Subscribing to " << chatter_topic << std::endl;
+  ros::Subscriber chatter_sub = n.subscribe( chatter_topic, 10, chatter_cb );
+
+  loop_rate.sleep();
+  std::cout << "Subscribing to " << counter_topic << std::endl;
+  ros::Subscriber counter_sub = n.subscribe( counter_topic, 10, counter_cb );
+
+  loop_rate.sleep();
+  ros::spin();
+
+  return 0;
+}

--- a/test/test_secure_ros/src/talker.cpp
+++ b/test/test_secure_ros/src/talker.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017, SRI International
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+#include "std_msgs/Int64.h"
+
+#include <sstream>
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "talker");
+  ros::NodeHandle n;
+  ros::Rate loop_rate(1);
+
+  loop_rate.sleep();
+
+  std::string chatter_topic( "/chatter" );
+  std::cout << "Publishing to " << chatter_topic << std::endl;
+  ros::Publisher chatter_pub = n.advertise<std_msgs::String>( chatter_topic, 10);
+
+  loop_rate.sleep();
+
+  std::string counter_topic( "/counter" );
+  std::cout << "Publishing to " << counter_topic << std::endl;
+  ros::Publisher counter_pub = n.advertise<std_msgs::Int64>( counter_topic, 10);
+
+  loop_rate.sleep();
+
+  int count = 0;
+  std_msgs::String chatter_msg;
+  std_msgs::Int64 counter_msg;
+  while ( ros::ok() ) {
+    std::stringstream ss;
+    ss << "hello world " << count;
+    chatter_msg.data = ss.str();
+    counter_msg.data = count;
+
+    if ( count % 10 == 0 ) {
+      ROS_INFO( "%d. %s <- %s", count, chatter_topic.c_str(), chatter_msg.data.c_str() );
+    }
+    chatter_pub.publish(chatter_msg);
+
+    loop_rate.sleep();
+
+    if ( count % 10 == 0 ) {
+      ROS_INFO( "%d. %s <- %ld", count, counter_topic.c_str(), counter_msg.data );
+    }
+    counter_pub.publish(counter_msg);
+
+    loop_rate.sleep();
+
+    ros::spinOnce();
+    ++count;
+  }
+
+  return 0;
+}

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -99,7 +99,8 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
 
     def insert_multicall_client_ip( self, doc ):
         """ Function to add client IP address for a multicall XMLRPC request
-            If method shutdown is called without optional "msg" argument, insert that as well
+            If method shutdown is called without optional "msg" argument, insert that as well so 
+            that the XMLRPC dispatch is done correctly
         """
         structs = doc.getElementsByTagName("struct")
         for s in structs:
@@ -122,6 +123,7 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                     else:
                         self.logger.warn( "multicall: unexpected entry %s" % name.data )
                 if methodName == "shutdown":
+                    # insert optional argument 'msg' for shutdown() if not provided
                     params = ElementTree.fromstring( datas.toxml() ).findall( "param" )
                     if len( params ) == 1:
                         self.logger.debug( "multicall: added msg param to shutdown()" )
@@ -134,7 +136,8 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
 
     def decode_request_content(self, data):
         """ Function to add client IP address for a XMLRPC request for secure methods
-            If method shutdown is called without optional "msg" argument, insert that as well
+            If method shutdown is called without optional "msg" argument, insert that as well so 
+            that the XMLRPC dispatch is done correctly
         """
         data = SimpleXMLRPCRequestHandler.decode_request_content(self, data)
         doc = parseString(data)
@@ -151,6 +154,7 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                   </value></param>''' % (self.client_ip,))
             p = pdoc.firstChild.cloneNode(True)
             if methodName == "shutdown":
+                # insert optional argument 'msg' for shutdown() if not provided
                 params = ElementTree.fromstring( ps.toxml() ).findall( "param" )
                 if len( params ) == 1:
                     self.logger.debug( "added msg param to shutdown()" )

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -31,6 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 # Revision $Id: xmlrpc.py 15336 2011-11-07 20:43:00Z kwc $
+# 
 
 from __future__ import print_function
 
@@ -66,6 +67,8 @@ except ImportError:
 
 import rosgraph.network
 
+from xml.dom.minidom import parseString
+
 def isstring(s):
     """Small helper version to check an object is a string in a way that works
     for both Python 2 and 3
@@ -75,11 +78,85 @@ def isstring(s):
     except NameError:
         return isinstance(s, str)
 
+count = 0
+
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     def log_message(self, format, *args):
         if 0:
             SimpleXMLRPCRequestHandler.log_message(self, format, *args)
     
+class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
+    logger = logging.getLogger('roslaunch.auth')            
+    secure_methods = [ "registerPublisher", "registerSubscriber", "registerService", "lookupService",
+            "unregisterPublisher", "unregisterSubscriber", "unregisterService",
+            "publisherUpdate", "requestTopic", "shutdown", "paramUpdate",
+            "lookupNode", "getPublishedTopics", "getTopicTypes", "getSystemState",
+            "deleteParam", "setParam",
+            "getParam", "searchParam", "subscribeParam", "unsubscribeParam", "hasParam", "getParamNames",
+            "getServiceClients" ]
+
+    def __init__(self, request, client_address, server):
+        self.client_ip, self.client_port = client_address 
+        self.logger.debug( "==== received XMLRPC (from %s:%s)" % ( self.client_ip, self.client_port ) )
+        SimpleXMLRPCRequestHandler.__init__(self, request, client_address, server)
+
+    def insert_multicall_client_ip( self, doc ):
+        structs = doc.getElementsByTagName("struct")
+        for s in structs:
+            try:
+                members = s.getElementsByTagName( "member" )
+                methodName = None
+                datas = None
+                for m in members:
+                    name = m.getElementsByTagName( "name" )[0].childNodes[0]
+                    value = m.getElementsByTagName( "value" )[0]
+                    if name.data == 'methodName':
+                        for v in value.childNodes:
+                            if v.nodeType == v.ELEMENT_NODE:
+                                methodName = v.childNodes[0].data
+                                self.logger.debug( "multicall: %s" % methodName )
+                                break
+                    elif name.data == 'params':
+                        arrays = value.getElementsByTagName( "array" )
+                        datas = arrays[0].getElementsByTagName( "data" )[0]
+                    else:
+                        self.logger.warn( "multicall: unexpected entry %s" % name.data )
+                if methodName in self.secure_methods:
+                    ddoc = parseString( "<value><string>%s</string></value>\n" % self.client_ip )
+                    d = ddoc.firstChild.cloneNode(True)
+                    datas.appendChild(d)
+            except:
+              self.logger.warn( "XML system.multicall parsing error" )
+
+    def decode_request_content(self, data):
+        global count 
+        count = count + 1
+        data = SimpleXMLRPCRequestHandler.decode_request_content(self, data)
+        doc = parseString(data)
+        ps = doc.getElementsByTagName("params")[0]
+        
+        methodName = doc.getElementsByTagName("methodName")[0].childNodes[0].nodeValue
+        self.logger.info( "-- %s (from %s) --" % ( methodName, self.client_ip ) )
+        fname = "none.xml"
+        if methodName == "system.multicall":
+          self.insert_multicall_client_ip( doc )
+          fname = "multi_%d.xml" % count
+        else:
+          pdoc = parseString(
+             ''' <param><value>
+                  <string>%s</string>
+                  </value></param>''' % (self.client_ip,))
+          p = pdoc.firstChild.cloneNode(True)
+          fname = "single_%d.xml" % count
+          if methodName in self.secure_methods:
+            ps.appendChild(p)
+        if 0:
+            with open( fname, "w" ) as f:
+              f.write( "%s" % doc.toxml() )
+              print( "[xmlrpc] Writing XML to %s" % fname )
+        return doc.toxml()
+
+
 class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     """
     Adds ThreadingMixin to SimpleXMLRPCServer to support multiple concurrent
@@ -102,7 +179,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
             # We have to monipulate private members and duplicate
             # code from the constructor.
             # TODO IPV6: Get this into SimpleXMLRPCServer 
-            SimpleXMLRPCServer.__init__(self, addr, SilenceableXMLRPCRequestHandler, log_requests,  bind_and_activate=False)
+            SimpleXMLRPCServer.__init__(self, addr, IPSilenceableXMLRPCRequestHandler, log_requests,  bind_and_activate=False)
             self.address_family = socket.AF_INET6
             self.socket = socket.socket(self.address_family, self.socket_type)
             logger.info('binding ipv6 xmlrpc socket to' + str(addr))
@@ -112,7 +189,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
             self.server_activate()
             logger.info('bound to ' + str(self.socket.getsockname()[0:2]))
         else:
-            SimpleXMLRPCServer.__init__(self, addr, SilenceableXMLRPCRequestHandler, log_requests)
+            SimpleXMLRPCServer.__init__(self, addr, IPSilenceableXMLRPCRequestHandler, log_requests)
 
     def handle_error(self, request, client_address):
         """
@@ -229,7 +306,7 @@ class XmlRpcNode(object):
             port = self.port or 0 #0 = any
 
             bind_address = rosgraph.network.get_bind_address()
-            logger.info("XML-RPC server binding to %s:%d" % (bind_address, port))
+            logger.info("Modified XML-RPC server binding to %s:%d" % (bind_address, port))
             
             self.server = ThreadingXMLRPCServer((bind_address, port), log_requests)
             self.port = self.server.server_address[1] #set the port to whatever server bound to
@@ -268,7 +345,6 @@ class XmlRpcNode(object):
             else:
                 msg = "ERROR: Unable to start XML-RPC server: %s" % e.strerror
             logger.error(msg)
-            print(msg)
             raise #let higher level catch this
 
         if self.handler is not None:

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -91,14 +91,6 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
         to make the request.
     """
     logger = logging.getLogger('roslaunch.auth')            
-    secure_methods = [ "registerPublisher", "registerSubscriber", "registerService", "lookupService",
-            "unregisterPublisher", "unregisterSubscriber", "unregisterService",
-            "publisherUpdate", "requestTopic", "shutdown", "paramUpdate",
-            "lookupNode", "getPublishedTopics", "getTopicTypes", "getSystemState",
-            "deleteParam", "setParam",
-            "getParam", "searchParam", "subscribeParam", "unsubscribeParam", "hasParam", "getParamNames",
-            "getServiceClients", "getSubscriptions", "getPublications",
-            "getBusInfo", "getBusStats"]
 
     def __init__(self, request, client_address, server):
         self.client_ip, self.client_port = client_address 
@@ -129,15 +121,14 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                         datas = arrays[0].getElementsByTagName( "data" )[0]
                     else:
                         self.logger.warn( "multicall: unexpected entry %s" % name.data )
-                if methodName in self.secure_methods:
-                    if methodName == "shutdown":
-                        params = ElementTree.fromstring( datas.toxml() ).findall( "param" )
-                        if len( params ) == 1:
-                            self.logger.debug( "multicall: added msg param to shutdown()" )
-                            p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
-                            datas.appendChild(p2)
-                    p = parseString( "<value><string>%s</string></value>\n" % self.client_ip ).firstChild.cloneNode(True)
-                    datas.appendChild(p)
+                if methodName == "shutdown":
+                    params = ElementTree.fromstring( datas.toxml() ).findall( "param" )
+                    if len( params ) == 1:
+                        self.logger.debug( "multicall: added msg param to shutdown()" )
+                        p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
+                        datas.appendChild(p2)
+                p = parseString( "<value><string>%s</string></value>\n" % self.client_ip ).firstChild.cloneNode(True)
+                datas.appendChild(p)
             except:
               self.logger.warn( "XML system.multicall parsing error" )
 
@@ -159,14 +150,13 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                   <string>%s</string>
                   </value></param>''' % (self.client_ip,))
             p = pdoc.firstChild.cloneNode(True)
-            if methodName in self.secure_methods:
-                if methodName == "shutdown":
-                    params = ElementTree.fromstring( ps.toxml() ).findall( "param" )
-                    if len( params ) == 1:
-                        self.logger.debug( "added msg param to shutdown()" )
-                        p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
-                        ps.appendChild(p2)
-                ps.appendChild(p)
+            if methodName == "shutdown":
+                params = ElementTree.fromstring( ps.toxml() ).findall( "param" )
+                if len( params ) == 1:
+                    self.logger.debug( "added msg param to shutdown()" )
+                    p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
+                    ps.appendChild(p2)
+            ps.appendChild(p)
         return doc.toxml()
 
 

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -133,9 +133,9 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                     if methodName == "shutdown":
                         params = ElementTree.fromstring( datas.toxml() ).findall( "param" )
                         if len( params ) == 1:
+                            self.logger.debug( "multicall: added msg param to shutdown()" )
                             p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
                             datas.appendChild(p2)
-                        print( "shutdown()" )
                     p = parseString( "<value><string>%s</string></value>\n" % self.client_ip ).firstChild.cloneNode(True)
                     datas.appendChild(p)
             except:
@@ -163,9 +163,9 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
                 if methodName == "shutdown":
                     params = ElementTree.fromstring( ps.toxml() ).findall( "param" )
                     if len( params ) == 1:
+                        self.logger.debug( "added msg param to shutdown()" )
                         p2 = parseString( '''<param><value><string>silent</string></value></param>''' ).firstChild.cloneNode(True)
                         ps.appendChild(p2)
-                    #print( "shutdown: %s (%d param tags)" % ( ps.toxml(), len( params ) ) )
                 ps.appendChild(p)
         return doc.toxml()
 

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -97,7 +97,8 @@ class IPSilenceableXMLRPCRequestHandler(SilenceableXMLRPCRequestHandler):
             "lookupNode", "getPublishedTopics", "getTopicTypes", "getSystemState",
             "deleteParam", "setParam",
             "getParam", "searchParam", "subscribeParam", "unsubscribeParam", "hasParam", "getParamNames",
-            "getServiceClients" ]
+            "getServiceClients", "getSubscriptions", "getPublications",
+            "getBusInfo", "getBusStats"]
 
     def __init__(self, request, client_address, server):
         self.client_ip, self.client_port = client_address 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -268,6 +268,12 @@ def main(argv=sys.argv):
         logger = logging.getLogger('roslaunch')
         logger.info("roslaunch starting with args %s"%str(argv))
         logger.info("roslaunch env is %s"%os.environ)
+        # resolve full path of auth file while os.curdir is still valid 
+        if os.environ.has_key( "ROS_AUTH_FILE" ):
+            os.environ["ROS_AUTH_FILE"] = os.path.realpath( os.path.expanduser( os.environ["ROS_AUTH_FILE"] ) )
+            logger.info( "Resolving ROS_AUTH_FILE to %s" % os.environ["ROS_AUTH_FILE"] )
+        else:
+            logger.warn( "ROS_AUTH_FILE environment variable not set!" )
             
         if options.child_name:
             logger.info('starting in child mode')

--- a/tools/roslaunch/src/roslaunch/server.py
+++ b/tools/roslaunch/src/roslaunch/server.py
@@ -123,7 +123,7 @@ class ROSLaunchBaseHandler(xmlrpc.XmlRpcHandler):
         else:
             return 1, "process info", p.get_info()
 
-    def get_pid(self):
+    def get_pid(self, client_ip_address = "127.0.0.1" ):
         """
         @return: code, msg, pid
         @rtype: int, str, int

--- a/tools/rosmaster/src/rosmaster/authorization.py
+++ b/tools/rosmaster/src/rosmaster/authorization.py
@@ -1,4 +1,3 @@
-# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2017, SRI International
@@ -32,8 +31,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 """
-ROS Master authorization
-This class loads the rules from a file and provides functions to authorize connections
+ROS Master authorization for Secure ROS
+This class loads the rules from file and provides functions to 
+check if clients (IP address) are authorized to make XMLRPC requests.
 """
 
 from __future__ import print_function

--- a/tools/rosmaster/src/rosmaster/authorization.py
+++ b/tools/rosmaster/src/rosmaster/authorization.py
@@ -1,0 +1,446 @@
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, SRI International
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+"""
+ROS Master authorization
+This class loads the rules from a file and provides functions to authorize connections
+"""
+
+from __future__ import print_function
+
+import os
+import yaml
+import socket
+import warnings
+import logging
+import rospkg
+from itertools import chain
+from urlparse import urlparse
+from collections import OrderedDict
+
+
+def getLogger( ):
+    if getLogger.logger == None:
+        formatter = logging.Formatter('[auth][%(levelname)s] %(message)s')
+        handler = logging.StreamHandler( )
+        handler.setFormatter( formatter )
+        handler.setLevel( logging.INFO )
+        getLogger.logger = logging.getLogger( "roslaunch.auth" )
+        getLogger.logger.setLevel( logging.DEBUG )
+        getLogger.logger.addHandler( handler )
+    return getLogger.logger
+
+getLogger.logger = None
+
+
+def resolve_ip_address( ip_address ):
+    """ Convert host or IP address to a list of IP addresses """
+    try: 
+        _, _, ip_address_list = socket.gethostbyname_ex( ip_address )
+    except socket.gaierror as e:
+        msg = "A %s exception occurred (%s)" % ( type(e).__name__, ", ".join( "%s" % a for a in e.args ) )
+        getLogger().error( msg )
+        msg = "Unable to resolve hostname: %s" % ( ip_address )
+        getLogger().error( msg )
+        raise ImportError( msg )
+    except Exception as e:
+        msg = "A %s exception occurred (%s)" % ( type(e).__name__, ", ".join( "%s" % a for a in e.args ) )
+        getLogger().error( msg )
+        raise e
+    getLogger().debug( "%s resolved to %s" % ( ip_address, set( ip_address_list ) ) )
+    return set( ip_address_list )
+
+
+
+def resolve_ip_address_list( ip_address_list, aliases = dict() ):
+    ip_address_set = set()
+    for ip in ip_address_list:
+        if ip in aliases.keys():
+            ip_address_set.update( aliases[ip] )
+        else:
+            ip_address_set.update( resolve_ip_address( ip ) )
+    return ip_address_set 
+        
+
+
+def uri_to_ip_address_list( uri ):
+    """ Convert a URI to an IP address list
+    """
+    try:
+        parsed_uri = urlparse( uri )
+        _, _, ip_address_list = socket.gethostbyname_ex( parsed_uri.hostname )
+    except Exception as e:
+        getLogger().error( "Error: %s is not a valid URI (error=%s)" % ( uri, e.strerror ) )
+        return []
+    getLogger().debug( "uri_to_ip_address_list(%s) = %s" % ( parsed_uri.hostname, ip_address_list) )
+    return ip_address_list 
+
+
+def is_local_ip_address( ip_addr ):
+    """ Check if the address is a local address, i.e. begins with a 127
+    """
+    return True if ip_addr.startswith( "127." ) or ip_addr.startswith( "169.254." ) else False
+
+
+def is_local_uri( uri ):
+    """ Check if the URI is a local address, i.e. begins with a 127
+    """
+    return any( [ is_local_ip_address( addr ) for addr in uri_to_ip_address_list( uri ) ] )
+
+
+def is_uri_match( uri, ip_address ):
+    """ Check if uri matches IP address
+    """
+    uri_ip_address_list = uri_to_ip_address_list( uri )
+    if is_local_ip_address( ip_address ):
+        if any( [ is_local_ip_address( addr ) for addr in uri_ip_address_list ] ):
+            getLogger().debug( "is_uri_match( %s, %s ): OK (local IP address)" % ( uri, ip_address ) )
+            return True
+        else:
+            getLogger().debug( "is_uri_match( %s, %s ): No (local IP address)" % ( uri, ip_address ) )
+            return False
+    else:
+        if ip_address in uri_ip_address_list:
+            getLogger().debug( "is_uri_match( %s, %s ): OK" % ( uri, ip_address ) )
+            return True
+        else:
+            getLogger().debug( "is_uri_match( %s, %s ): No" % ( uri, ip_address ) )
+            return False
+
+
+class ROSMasterAuth():
+    """
+            publishers is a dictionary such that subscribers[topic] = list_of_subscriber_ip_addresses_for_that_topic
+            subscribers is a dictionary such that publishers[topic] = list_of_publishers_ip_addresses_for_that_topic
+            nodes is a dictionary such that nodes[node] = ip_address_for_that_node
+            ip_addresses is a set of all IP addresses from which nodes, subscribers and publishers are allowed
+            peer_publishers is a dictionary such that peer_publishers[ip_address] = set_of_publisher_ip_addresses_to_that_ip_address
+    """
+    reserved_parameters = ["/run_id", "/rosversion", "/rosdistro", "/tcp_keepalive", "/use_sim_time",
+            "/enable_statistics", "/statistics_window_min_elements", "/statistics_window_max_elements", 
+            "/statistics_window_min_size", "/statistics_window_max_size" ]
+    reserved_topics = ["/rosout", "/rosout_agg"]
+    reserved_nodes = ["/rosout"]
+
+    def __init__( self, config_file = "", is_master = True ):
+        self.noverify = False
+        self.master = set()
+        self.aliases = dict()
+        self.subscribers = dict()
+        self.publishers = dict()
+        self.providers = dict()
+        self.requesters = dict()
+        self.methods = dict()
+        self.nodes = dict()
+        self.peer_publishers = dict()
+        self.setters = dict()
+        self.getters = dict()
+        self.ip_addresses = set()
+        self.logger = getLogger()
+
+        """ Set ROS master IP address """
+        if is_master: 
+            if os.environ.has_key( "ROS_MASTER_URI" ):
+                self.master = set( uri_to_ip_address_list( os.environ.get( "ROS_MASTER_URI" ) ) )
+            else:
+                raise RuntimeError( "ROS_MASTER_URI environment variable not set" )
+        self.master.update( resolve_ip_address( "localhost" ) )
+        self.logger.info( "Setting master from ROS_MASTER_URI: %s" % self.master )
+
+        """ ROS authorization configuration file is stored in environment variable """
+        if config_file == "":
+            if os.environ.has_key( "ROS_AUTH_FILE" ):
+                config_file = os.environ.get( "ROS_AUTH_FILE" )
+        if config_file == "":
+            self.noverify = True
+            self.logger.warn( "Authorization configuration file not specified. Secure ROS is disabled!" )
+        elif not os.path.exists( config_file ):
+            raise RuntimeError( "Authorization configuration file %s does not exist" % config_file )
+        else:
+            self.logger.info( "Loading authorization from %s" % config_file )
+            self.load( config_file )
+        output_file = "%s/ros_auth_full.yaml" % rospkg.get_log_dir( env = os.environ )
+        self.logger.info( "Writing full authorization to %s" % output_file )
+        self.save( output_file )
+
+
+    def resolve( self, ip_address_list ):
+        """ Resolve ip_address_list where each ip_address may be an IP address, Host name or alias
+        """
+        return resolve_ip_address_list( ip_address_list, self.aliases )
+
+
+    def load( self, config_file ):
+        """ Load authorization file
+        """
+        doc = None
+        try:
+            with open( config_file, "r" ) as f:
+                doc = yaml.load( f )
+        except:
+            raise ImportError( "Failed to read authorization file %s:" % config_file )
+        if doc != None:
+            if "aliases" in doc.keys():
+                for key, val in doc["aliases"].items():
+                    self.aliases[key] = resolve_ip_address_list( val )
+                self.aliases = doc["aliases"]
+            if "topics" in doc.keys():
+                for k, v in doc["topics"].items():
+                    if k in self.reserved_topics:
+                        raise ImportError('Topic %s is a reserved topic!' % k )
+                    if "publishers" in v.keys():
+                        self.publishers[k] = self.resolve( v["publishers"] ) 
+                    else:
+                        raise ImportError('Topic %s does not have publishers!' % k )
+                    if "subscribers" in v.keys():
+                        self.subscribers[k] = self.resolve( v["subscribers"] ) | self.publishers[k]
+                    else:
+                        self.logger.warn('Topic %s does not have subscribers!' % k )
+            else:
+                raise ImportError( "Authorization file %s does not contain topics" % config_file )
+
+            if "nodes" in doc.keys():
+                for k, v in doc["nodes"].items():
+                    if k in self.reserved_nodes:
+                        raise ImportError('Topic %s is a reserved node!' % k )
+                    self.nodes[k] = self.resolve( v )
+            else:
+                self.logger.warn( "Authorization file %s does not contain nodes" % config_file )
+
+            if "services" in doc.keys():
+                for k, v in doc["services"].items():
+                    if "providers" in v.keys():
+                        self.providers[k] = self.resolve( v["providers"] )
+                    else:
+                        raise ImportError('Service %s does not have providers!' % k )
+                    if "requesters" in v.keys():
+                        self.requesters[k] = self.resolve( v["requesters"] ) | self.providers[k]
+                    else:
+                        self.logger.warn('Service %s does not have requesters!' % k )
+            else:
+                self.logger.warn( "Authorization file %s does not contain services" % config_file )
+
+            if "parameters" in doc.keys():
+                for k, v in doc["parameters"].items():
+                    if k in self.reserved_parameters:
+                        raise ImportError('Parameter %s is a reserved topic!' % k )
+                    if "setters" in v.keys():
+                        self.setters[k] = self.resolve( v["setters"] )
+                    else:
+                        raise ImportError('Parameter %s does not have setters!' % k )
+                    if "getters" in v.keys():
+                        self.getters[k] = self.resolve( v["getters"] ) | self.setters[k]
+                    else:
+                        self.logger.warn( 'Parameter %s does not have getters!' % k )
+            else:
+                self.logger.warn( "Authorization file %s does not contain parameters" % config_file )
+                pass
+        else:
+            raise ImportError( "Authorization file is empty" )
+
+        """ set pub/sub for reserved topics """
+
+        self.publishers["/rosout"] = set( ip for ips in chain( self.publishers.values(), self.subscribers.values() ) for ip in ips ) 
+        self.subscribers["/rosout"] = self.master 
+
+        self.publishers["/rosout_agg"] = self.master
+        self.subscribers["/rosout_agg"] = self.master
+
+        """ set ip_address for reserved nodes """
+
+        self.nodes["/rosout"] = self.master
+
+        """ compute peer publishers for each subscriber IP addresses """
+        topics = set( self.publishers.keys() + self.subscribers.keys() )
+        self.peer_publishers = { s: set() for subs in self.subscribers.values() for s in subs }
+        for t in topics:
+            for s in self.subscribers[t]:
+                self.peer_publishers[s].update( set( self.publishers[t] ) )
+
+        """ compute all authorized ip addresses """
+
+        self.ip_addresses = set( ip for ip in chain.from_iterable( self.nodes.values() ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.publishers.values() ) ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.subscribers.values() ) ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.providers.values() ) ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.requesters.values() ) ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.setters.values() ) ) )
+        self.ip_addresses.update( set( ip for ip in chain.from_iterable( self.getters.values() ) ) )
+
+        """ set setters/getters for reserved parameters """
+        for p in self.reserved_parameters:
+            self.setters[p] = self.master
+            self.getters[p] = self.ip_addresses
+        
+
+    def save( self, filename ):
+        """ Write full authorization configuration to YAML file
+        """
+        data = OrderedDict()
+        data.update( {"master": list( self.master ) } )
+        data.update( {"aliases": { k: list( v ) for k, v in self.aliases.items() } } )
+        data.update( {"nodes": { k: list( v ) for k, v in self.nodes.items() } } )
+        data.update( {"publishers": { k: list( v ) for k, v in self.publishers.items() } } )
+        data.update( {"subscribers": { k: list( v ) for k, v in self.subscribers.items() } } )
+        data.update( {"peer_publishers": { k: list( v ) for k, v in self.peer_publishers.items() } } )
+        data.update( {"setters": { k: list( v ) for k, v in self.setters.items() } } )
+        data.update( {"getters": { k: list( v ) for k, v in self.getters.items() } } )
+        data.update( {"providers": { k: list( v ) for k, v in self.providers.items() } } )
+        data.update( {"requesters": { k: list( v ) for k, v in self.requesters.items() } } )
+        data.update( {"ip_addresses": list( self.ip_addresses ) } )
+        represent_dict_order = lambda self, data:  self.represent_mapping('tag:yaml.org,2002:map', data.items())
+        yaml.add_representer(OrderedDict, represent_dict_order)    
+        with open( filename, "w" ) as handle:
+            yaml.dump( data, handle )
+
+
+    def check_key_ip_address( self, key, ip_address, auth_ip_addresses, query, fallback = False, prefix = False ):
+        """ Check if ip_address is present in auth_ip_addresses[key]
+            If prefix == True check if ip_address is present in auth_ip_addresses[key2] where key2 is a parent of key
+            If there exists key2 which is a parent of 
+            The parents of /a/bc/def/g are /a/bc/def, /a/bc, /a (not /a/b or /a/bc/de)
+        """
+        if self.noverify == True:
+            self.logger.debug( "%s( %s, %s ): %s (noverify = True)" % ( query, key, ip_address, True ) )
+            return True 
+        try:
+            if ip_address in self.ip_addresses:
+                for key2, val2 in auth_ip_addresses.items():
+                    if key == key2:
+                        if ip_address in val2:
+                            self.logger.debug( "%s( %s, %s ): %s" % ( query, key, ip_address, "OK" ) )
+                            return True
+                        else:
+                            self.logger.debug( "%s( %s, %s ): %s (IP address not authorized)" % ( query, key, ip_address, "No" ) )
+                            return False
+                    if prefix and key.startswith( key2 ):
+                        comp = key.split( "/" )
+                        for i in range( 1, len( comp ) ):
+                            if key2 == "/".join( c for c in comp[0:i+1] ):
+                                if ip_address in val2:
+                                    self.logger.debug( "%s( %s, %s ): %s (key prefix matches)" % ( query, key, ip_address, "OK" ) )
+                                    return True
+                                else:
+                                    self.logger.warn( "%s( %s, %s ): %s (key prefix matches)" % ( query, key, ip_address, "No" ) )
+                                    return False
+                if fallback:
+                    self.logger.debug( "%s( %s, %s ): %s (key not listed)" % ( query, key, ip_address, "OK" ) )
+                else:
+                    self.logger.warn( "%s( %s, %s ): %s (key not listed)" % ( query, key, ip_address, "No" ) )
+                return fallback 
+            self.logger.warn( "%s( %s, %s ): %s (unknown IP address)" % ( query, key, ip_address, "No" ) )
+            return False
+        except:
+            self.logger.error( "Error querying %s( %s, %s )" % ( query, key, ip_address ) )
+            return False
+
+
+    def check_caller_id( self, caller_id, ip_address ):
+        """ Check if caller_id is allowed from ip_address
+                Allow caller_id if is not listed (fallback = True)
+                Return True if allowed
+        """
+        return self.check_key_ip_address( caller_id, ip_address, self.nodes, "allow_node", fallback = True )
+
+
+    def check_publisher( self, topic, ip_address ):
+        """ Check if ip_address is allowed to publish to topic 
+                Return True if allowed
+        """
+        return self.check_key_ip_address( topic, ip_address, self.publishers, "allow_publisher" )
+
+
+    def check_subscriber( self, topic, ip_address ):
+        """ Check if ip_address is allowed to publish to topic 
+                Return True if allowed
+        """
+        return self.check_key_ip_address( topic, ip_address, self.subscribers, "allow_subscriber" )
+
+
+    def check_method( self, method, ip_address ):
+        """ Check if method is allowed from ip_address
+                Allow method if it is not listed (fallback = True)
+                Return True if allowed
+        """
+        return self.check_key_ip_address( method, ip_address, self.methods, "allow_method" )
+
+
+    def check_peer_publisher_to_api( self, subscriber_uri, pub_ip_address ):
+        """ Check if pub_ip_address is a publisher to sub_ip_address
+                Return true if no verification 
+        """
+        for sub_ip_address in uri_to_ip_address_list( subscriber_uri ):
+                if self.check_key_ip_address( sub_ip_address, pub_ip_address, self.peer_publishers, "allow_peer_publisher" ):
+                        return True
+        return False
+
+
+    def check_provider( self, service, ip_address ):
+        """ Check if ip_address is allowed to provide the service 
+                Allow if service is not listed (fallback = True)
+                Return True if allowed
+        """
+        return self.check_key_ip_address( service, ip_address, self.providers, "allow_provider", fallback = True )
+
+
+    def check_requester( self, service, ip_address ):
+        """ Check if ip_address is allowed to request the service 
+                Allow if service is not listed (fallback = True)
+                Return True if allowed
+        """
+        return self.check_key_ip_address( service, ip_address, self.requesters, "allow_requester", fallback = True )
+
+
+    def check_param_setter( self, param, ip_address ):
+        """ Check if param or prefix of param is allowed to be set from ip_address
+                Allow if param is not listed (fallback = True)
+                Return True if allowed
+        """
+        return self.check_key_ip_address( param, ip_address, self.setters, "allow_set_param", fallback = True, prefix = True )
+
+
+    def check_param_getter( self, param, ip_address ):
+        """ Return true if no verification 
+        """
+        return self.check_key_ip_address( param, ip_address, self.getters, "allow_get_param", fallback = True, prefix = True )
+
+
+    def service_clients( self, service ):
+        """ Return list of authorized clients for service 
+                Allow if service is not listed (fallback = True)
+                Return True if allowed
+        """
+        if service in self.requesters.keys():
+            return list( self.requesters[service] )
+        return list( self.ip_addresses )
+

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -321,22 +321,27 @@ class ROSMasterHandler(object):
         self._shutdown('external shutdown request from [%s]: %s'%(caller_id, msg))
         return 1, "shutdown", 0
         
-    @apivalidate('')
-    def getUri(self, caller_id):
+    @apivalidate('', (is_ipv4('client_ip_address'),))
+    def getUri(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Get the XML-RPC URI of this server.
         @param caller_id str: ROS caller id    
+        @type  caller_id: str
+        @param client_ip_address: IP address of client making request
+        @type  client_ip_address: str 
         @return [int, str, str]: [1, "", xmlRpcUri]
         """
         return 1, "", self.uri
 
         
-    @apivalidate(-1)
-    def getPid(self, caller_id):
+    @apivalidate(-1, (is_ipv4('client_ip_address'),))
+    def getPid(self, caller_id, client_ip_address = "127.0.0.1"):
         """
         Get the PID of this server
         @param caller_id: ROS caller id
         @type  caller_id: str
+        @param client_ip_address: IP address of client making request
+        @type  client_ip_address: str 
         @return: [1, "", serverProcessPID]
         @rtype: [int, str, int]
         """

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -308,8 +308,6 @@ class ROSMasterHandler(object):
         @type  msg: str
         @param client_ip_address: IP address of client making request
         @type  client_ip_address: str 
-        @param client_ip_address: IP address of client making request
-        @type  client_ip_address: str 
         @return: [code, msg, 0]
         @rtype: [int, str, int]
         """
@@ -328,8 +326,6 @@ class ROSMasterHandler(object):
         """
         Get the XML-RPC URI of this server.
         @param caller_id str: ROS caller id    
-        @param client_ip_address: IP address of client making request
-        @type  client_ip_address: str 
         @return [int, str, str]: [1, "", xmlRpcUri]
         """
         return 1, "", self.uri
@@ -341,8 +337,6 @@ class ROSMasterHandler(object):
         Get the PID of this server
         @param caller_id: ROS caller id
         @type  caller_id: str
-        @param client_ip_address: IP address of client making request
-        @type  client_ip_address: str 
         @return: [1, "", serverProcessPID]
         @rtype: [int, str, int]
         """
@@ -360,8 +354,6 @@ class ROSMasterHandler(object):
         @type  caller_id: str
         @param key: parameter name
         @type  key: str
-        @param client_ip_address: IP address of client making request
-        @type  client_ip_address: str 
         @param client_ip_address: IP address of client making request
         @type  client_ip_address: str 
         @return: [code, msg, 0]
@@ -981,7 +973,7 @@ class ROSMasterHandler(object):
     def getPublishedTopics(self, caller_id, subgraph, client_ip_address = "127.0.0.1"):
         """
         Get list of topics that can be subscribed to. This does not return topics that have no publishers.
-        This only returns topics that the client is authorized to subscribe to [sros].
+        This only returns topics that the client is authorized to subscribe to.
         See L{getSystemState()} to get more comprehensive list.
         @param caller_id: ROS caller id
         @type  caller_id: str
@@ -1010,7 +1002,7 @@ class ROSMasterHandler(object):
     def getTopicTypes(self, caller_id, client_ip_address = "127.0.0.1"): 
         """
         Retrieve list topic names and their types.
-        This only returns topics that the client is authorized to subscribe to [sros].
+        This only returns topics that the client is authorized to subscribe to.
         @param caller_id: ROS caller id    
         @type  caller_id: str
         @rtype: (int, str, [[str,str]] )

--- a/tools/rosmaster/src/rosmaster/validators.py
+++ b/tools/rosmaster/src/rosmaster/validators.py
@@ -86,6 +86,26 @@ def not_none(param_name):
 
 # Validators ######################################
 
+def is_ipv4(param_name):
+    """
+    Validator that checks that parameter is a valid IPv4 address
+    """
+    def validator(param_value, callerId):
+        #print( "validating: %s" % param_value )
+        if param_value == "":
+          param_value = "0.0.0.0"
+        if not isstring( param_value ):
+          print( "[xmlrpc] ERROR: parameter [%s] is not a string" % param_value )
+          raise ParameterInvalid("ERROR: parameter [%s] is not a string" % param_name)
+        try:
+          import socket 
+          socket.inet_aton( param_value )
+        except:
+          print( "[xmlrpc] ERROR: Parameter [%s] is illegal IP address" % param_value )
+          raise ParameterInvalid("ERROR: parameter [%s] is illegal IP address " % param_name)
+        return param_value
+    return validator
+
 def is_api(paramName):
     """
     Validator that checks that parameter is a valid API handle

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcClientInfo.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcClientInfo.h
@@ -1,0 +1,16 @@
+#ifndef _XMLRPCCLIENTINFO_H_
+#define _XMLRPCCLIENTINFO_H_
+
+#include <string>
+
+namespace XmlRpc
+{
+  struct XmlRpcClientInfo
+  {
+    short family;
+    unsigned short port;
+    std::string ip;
+  };
+}
+
+#endif // _XMLRPCCLIENTINFO_H_

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
@@ -19,6 +19,7 @@
 #include "xmlrpcpp/XmlRpcDispatch.h"
 #include "xmlrpcpp/XmlRpcSource.h"
 #include "xmlrpcpp/XmlRpcDecl.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 namespace XmlRpc {
 
@@ -82,6 +83,13 @@ namespace XmlRpc {
 
     inline int get_port() { return _port; }
 
+    XmlRpcClientInfo findClientInfo(int fd, XmlRpcClientInfo &ci) {
+      ci.ip = map_ip[fd];
+      ci.port = map_port[fd];
+      ci.family = map_family[fd];
+      return ci;
+    }
+
     XmlRpcDispatch *get_dispatch() { return &_disp; }
 
   protected:
@@ -107,7 +115,10 @@ namespace XmlRpc {
     XmlRpcServerMethod* _methodHelp;
 
     int _port;
-
+    XmlRpcClientInfo _clientInfo;
+    std::map<int,std::string> map_ip;
+    std::map<int,short> map_family;
+    std::map<int,int> map_port;
   };
 } // namespace XmlRpc
 

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServerMethod.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServerMethod.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "xmlrpcpp/XmlRpcDecl.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 #ifndef MAKEDEPEND
 # include <string>
@@ -34,7 +35,7 @@ namespace XmlRpc {
     std::string& name() { return _name; }
 
     //! Execute the method. Subclasses must provide a definition for this method.
-    virtual void execute(XmlRpcValue& params, XmlRpcValue& result) = 0;
+    virtual void execute(XmlRpcValue& params, XmlRpcClientInfo &ci, XmlRpcValue& result) = 0;
 
     //! Returns a help string for the method.
     //! Subclasses should define this method if introspection is being used.

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcSocket.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcSocket.h
@@ -16,6 +16,7 @@
 #endif
 
 #include "xmlrpcpp/XmlRpcDecl.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 namespace XmlRpc {
 
@@ -57,9 +58,8 @@ namespace XmlRpc {
     static bool listen(int socket, int backlog);
 
     //! Accept a client connection request
-    static int accept(int socket);
-
-
+    //static int accept(int socket);
+    static int accept(int socket, XmlRpcClientInfo &ci);
 
     //! Connect a socket to a server (from a client)
     static bool connect(int socket, std::string& host, int port);

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcSource.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcSource.h
@@ -9,6 +9,7 @@
 #endif
 
 #include "xmlrpcpp/XmlRpcDecl.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 namespace XmlRpc {
 
@@ -39,7 +40,12 @@ namespace XmlRpc {
     //! Return true to continue monitoring this source
     virtual unsigned handleEvent(unsigned eventType) = 0;
 
+    XmlRpcClientInfo getClientInfo() { return _clientInfo; }
+
   private:
+
+    // Client information including IP address 
+    XmlRpcClientInfo _clientInfo;
 
     // Socket. This should really be a SOCKET (an alias for unsigned int*) on windows...
     int _fd;

--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -9,7 +9,6 @@
 #include "xmlrpcpp/XmlRpcUtil.h"
 #include "xmlrpcpp/XmlRpcException.h"
 #include "xmlrpcpp/XmlRpcClientInfo.h"
-#include <stdio.h>
 
 
 using namespace XmlRpc;
@@ -152,14 +151,11 @@ XmlRpcServer::handleEvent(unsigned)
 void
 XmlRpcServer::acceptConnection()
 {
-  //ClientInfo& info = getClientInfo();
   int s = XmlRpcSocket::accept(this->getfd(), _clientInfo);
 
   map_ip[s] = _clientInfo.ip;
   map_port[s] = _clientInfo.port;
   map_family[s] = _clientInfo.family;
-
-  //printf( "[xmlrpc_cpp] accept connection from ip %s port %d fd %d\n", _clientInfo.ip.c_str(), _clientInfo.port, s);
 
   XmlRpcUtil::log(2, "XmlRpcServer::acceptConnection: socket %d", s);
   if (s < 0)

--- a/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
@@ -256,6 +256,7 @@ XmlRpcServerConnection::parseRequest(XmlRpcValue& params)
 }
 
 // Execute a named method with the specified params.
+// Note that it adds the XmlRpcClientInfo to allow authentication.
 bool
 XmlRpcServerConnection::executeMethod(const std::string& methodName, 
                                       XmlRpcValue& params, XmlRpcValue& result)

--- a/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
@@ -1,5 +1,6 @@
 
 #include "xmlrpcpp/XmlRpcServerConnection.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 #include "xmlrpcpp/XmlRpcSocket.h"
 #include "xmlrpcpp/XmlRpc.h"
@@ -259,11 +260,13 @@ bool
 XmlRpcServerConnection::executeMethod(const std::string& methodName, 
                                       XmlRpcValue& params, XmlRpcValue& result)
 {
+  XmlRpcClientInfo ci;
   XmlRpcServerMethod* method = _server->findMethod(methodName);
+  _server->findClientInfo(getfd(), ci);
 
   if ( ! method) return false;
 
-  method->execute(params, result);
+  method->execute(params, ci, result);
 
   // Ensure a valid result value
   if ( ! result.valid())

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -187,24 +187,20 @@ XmlRpcSocket::accept(int fd, XmlRpcClientInfo& clientInfo)
 #else
   socklen_t
 #endif
-  addrlen = sizeof(addr);
+    addrlen = sizeof(addr);
   // accept will truncate the address if the buffer is too small.
   // As we are not using it, no special case for IPv6
   // has to be made.
-
   int result = (int) ::accept(fd, (struct sockaddr*)&addr, &addrlen);
 
   struct sockaddr_in* inaddr_ptr = (struct sockaddr_in *)&addr;
   char *ip = inet_ntoa(inaddr_ptr->sin_addr);
-
-  //printf("[xmlrpc_cpp] user request from ip address %s port %d \n", ip, inaddr_ptr->sin_port);
 
   clientInfo.family = inaddr_ptr->sin_family;
   clientInfo.port = inaddr_ptr->sin_port;
   clientInfo.ip = std::string(ip);
 
   return result;
-  //return (int) ::accept(fd, (struct sockaddr*)&addr, &addrlen);
 }
 
 

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -4,6 +4,7 @@
 
 #include "xmlrpcpp/XmlRpcSocket.h"
 #include "xmlrpcpp/XmlRpcUtil.h"
+#include "xmlrpcpp/XmlRpcClientInfo.h"
 
 #ifndef MAKEDEPEND
 
@@ -178,7 +179,7 @@ XmlRpcSocket::listen(int fd, int backlog)
 
 
 int
-XmlRpcSocket::accept(int fd)
+XmlRpcSocket::accept(int fd, XmlRpcClientInfo& clientInfo)
 {
   struct sockaddr_in addr;
 #if defined(_WINDOWS)
@@ -186,11 +187,24 @@ XmlRpcSocket::accept(int fd)
 #else
   socklen_t
 #endif
-    addrlen = sizeof(addr);
+  addrlen = sizeof(addr);
   // accept will truncate the address if the buffer is too small.
   // As we are not using it, no special case for IPv6
   // has to be made.
-  return (int) ::accept(fd, (struct sockaddr*)&addr, &addrlen);
+
+  int result = (int) ::accept(fd, (struct sockaddr*)&addr, &addrlen);
+
+  struct sockaddr_in* inaddr_ptr = (struct sockaddr_in *)&addr;
+  char *ip = inet_ntoa(inaddr_ptr->sin_addr);
+
+  //printf("[xmlrpc_cpp] user request from ip address %s port %d \n", ip, inaddr_ptr->sin_port);
+
+  clientInfo.family = inaddr_ptr->sin_family;
+  clientInfo.port = inaddr_ptr->sin_port;
+  clientInfo.ip = std::string(ip);
+
+  return result;
+  //return (int) ::accept(fd, (struct sockaddr*)&addr, &addrlen);
 }
 
 


### PR DESCRIPTION
It makes sense to actually do the pull request here so that we keep our comments internally. Once we are both happy, we merge into our lunar-devel and then do a pull request to the main repository. We will see for the pull request about formatting in different commits or not, etc, let's not think about it for now except maybe doing fixes to the code in small commits if possible.

Here is a list of things to solve before we accept the pull request:
- [x] roscpp deprecated handling
  - Keep the functions ?
  - Mark them as deprecated in the comments and use a ROS_WARN in the code
  - Put a compile time attribute, seems like ROS_DEPRECATED macro from package.h is the guy
  - [x] proposing to just remove them.

- [x] rospy have `client_ip_addr` be an optional argument in the function, with default '127.0.0.1'

- [x] Have a bit more documentation
  - [x] authorization.py
  - [x] xmlrpc approach described at top level explaining the automatic last argument

